### PR TITLE
adds tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo doc --document-private-items --no-deps --open
   - [x] to `navigation.rs` to make sure the navigation in the data is ok
   - [x] to `app.rs` to make sure the application state machine works
   - [ ] to `parsing.rs` to make sure the parsing of the config works
-  - [ ] to `tui.rs` to make sure the rendering works as intended
+  - [x] to `tui.rs` to make sure the rendering works as intended
 - [ ] restrict the visibility of objects when possible
 - [ ] show true tables as such
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo doc --document-private-items --no-deps --open
 - [ ] when going into a file or URL, open it
 - [ ] give different colors to names and type
 - [ ] add tests...
-  - [ ] to `navigation.rs` to make sure the navigation in the data is ok
+  - [x] to `navigation.rs` to make sure the navigation in the data is ok
   - [x] to `app.rs` to make sure the application state machine works
   - [ ] to `parsing.rs` to make sure the parsing of the config works
   - [ ] to `tui.rs` to make sure the rendering works as intended

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ cargo doc --document-private-items --no-deps --open
 - [ ] add check for the config to make sure it's valid
 - [ ] when going into a file or URL, open it
 - [ ] give different colors to names and type
-- [ ] add tests...
+- [x] add tests...
   - [x] to `navigation.rs` to make sure the navigation in the data is ok
   - [x] to `app.rs` to make sure the application state machine works
-  - [ ] to `parsing.rs` to make sure the parsing of the config works
+  - [x] to `parsing.rs` to make sure the parsing of the config works
   - [x] to `tui.rs` to make sure the rendering works as intended
 - [ ] restrict the visibility of objects when possible
 - [ ] show true tables as such

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ cargo doc --document-private-items --no-deps --open
 - [ ] give different colors to names and type
 - [ ] add tests...
   - [ ] to `navigation.rs` to make sure the navigation in the data is ok
-  - [ ] to `app.rs` to make sure the application state machine works
+  - [x] to `app.rs` to make sure the application state machine works
   - [ ] to `parsing.rs` to make sure the parsing of the config works
   - [ ] to `tui.rs` to make sure the rendering works as intended
 - [ ] restrict the visibility of objects when possible

--- a/src/app.rs
+++ b/src/app.rs
@@ -247,42 +247,28 @@ mod tests {
 
         assert!(state.mode == Mode::Normal);
 
-        // NORMAL -> NORMAL
-        let result = transition_state(&keybindings.normal, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Normal);
+        let transitions = vec![
+            (&keybindings.normal, Mode::Normal, "NORMAL -> NORMAL"),
+            (&keybindings.insert, Mode::Insert, "NORMAL -> INSERT"),
+            (&keybindings.insert, Mode::Insert, "INSERT -> INSERT"),
+            (&keybindings.normal, Mode::Normal, "INSERT -> NORMAL"),
+            (&keybindings.peek, Mode::Peeking, "NORMAL -> PEEKING"),
+            (&keybindings.peek, Mode::Peeking, "PEEKING -> PEEKING"),
+            (&keybindings.normal, Mode::Normal, "PEEKING -> NORMAL"),
+            // INSERT -> PEEKING: not allowed
+            // PEEKING -> INSERT: not allowed
+        ];
 
-        // NORMAL -> INSERT
-        let result = transition_state(&keybindings.insert, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Insert);
-
-        // INSERT -> INSERT
-        let result = transition_state(&keybindings.insert, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Insert);
-
-        // INSERT -> NORMAL
-        let result = transition_state(&keybindings.normal, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Normal);
-
-        // NORMAL -> PEEKING
-        let result = transition_state(&keybindings.peek, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Peeking);
-
-        // PEEKING -> PEEKING
-        let result = transition_state(&keybindings.peek, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Peeking);
-
-        // PEEKING -> NORMAL
-        let result = transition_state(&keybindings.normal, &config, &mut state, &value).unwrap();
-        assert!(!result.exit);
-        assert!(state.mode == Mode::Normal);
-
-        // INSERT -> PEEKING: not allowed
-        // PEEKING -> INSERT: not allowed
+        for (key, expected_mode, transition) in transitions {
+            let result = transition_state(&key, &config, &mut state, &value).unwrap();
+            assert!(!result.exit, "unexpected exit on {}", transition);
+            assert!(
+                state.mode == expected_mode,
+                "expected {} on {}, found {}",
+                expected_mode,
+                transition,
+                state.mode
+            );
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -224,29 +224,18 @@ mod tests {
     ///     i: 123,
     /// }
     fn test_value() -> Value {
-        Value::record(
-            vec!["l".into(), "r".into(), "s".into(), "i".into()],
+        Value::test_record(
+            vec!["l", "r", "s", "i"],
             vec![
-                Value::list(
-                    vec![
-                        Value::string("my", Span::test_data()),
-                        Value::string("list", Span::test_data()),
-                        Value::string("elements", Span::test_data()),
-                    ],
-                    Span::test_data(),
-                ),
-                Value::record(
-                    vec!["a".into(), "b".into()],
-                    vec![
-                        Value::int(1, Span::test_data()),
-                        Value::int(2, Span::test_data()),
-                    ],
-                    Span::test_data(),
-                ),
-                Value::string("some string", Span::test_data()),
-                Value::int(123, Span::test_data()),
+                Value::test_list(vec![
+                    Value::test_string("my"),
+                    Value::test_string("list"),
+                    Value::test_string("elements"),
+                ]),
+                Value::test_record(vec!["a", "b"], vec![Value::test_int(1), Value::test_int(2)]),
+                Value::test_string("some string"),
+                Value::test_int(123),
             ],
-            Span::test_data(),
         )
     }
 
@@ -554,13 +543,9 @@ mod tests {
             (
                 &keybindings.peeking.current,
                 true,
-                Some(Value::record(
-                    vec!["a".into(), "b".into()],
-                    vec![
-                        Value::int(1, Span::test_data()),
-                        Value::int(2, Span::test_data()),
-                    ],
-                    Span::test_data(),
+                Some(Value::test_record(
+                    vec!["a", "b"],
+                    vec![Value::test_int(1), Value::test_int(2)],
                 )),
             ),
         ];
@@ -571,11 +556,7 @@ mod tests {
             (&keybindings.navigation.right, false, None), // on {r: {a: 1, b: 2}}
             (&keybindings.peek, false, None),
             (&keybindings.peeking.all, true, Some(value.clone())),
-            (
-                &keybindings.peeking.under,
-                true,
-                Some(Value::int(1, Span::test_data())),
-            ),
+            (&keybindings.peeking.under, true, Some(Value::test_int(1))),
         ];
         run_peeking_scenario(transitions, &config, &value);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,7 +107,7 @@ pub(super) fn run(
         terminal.draw(|frame| tui::render_ui(frame, input, &state, config))?;
 
         let key = console::Term::stderr().read_key()?;
-        match transition_state(key, config, &mut state, input)? {
+        match transition_state(&key, config, &mut state, input)? {
             TransitionResult { exit: true, result } => match result {
                 None => break,
                 Some(value) => return Ok(value),
@@ -121,55 +121,55 @@ pub(super) fn run(
 /// perform the state transition based on the key pressed and the previous state
 #[allow(clippy::collapsible_if)]
 fn transition_state(
-    key: Key,
+    key: &Key,
     config: &Config,
     state: &mut State,
     value: &Value,
 ) -> Result<TransitionResult, ShellError> {
-    if key == config.keybindings.quit {
+    if key == &config.keybindings.quit {
         return Ok(TransitionResult {
             exit: true,
             result: None,
         });
-    } else if key == config.keybindings.insert {
+    } else if key == &config.keybindings.insert {
         if state.mode == Mode::Normal {
             state.mode = Mode::Insert;
         }
-    } else if key == config.keybindings.normal {
+    } else if key == &config.keybindings.normal {
         if state.mode == Mode::Insert {
             state.mode = Mode::Normal;
         }
-    } else if key == config.keybindings.navigation.down {
+    } else if key == &config.keybindings.navigation.down {
         if state.mode == Mode::Normal {
             navigation::go_up_or_down_in_data(state, value, Direction::Down);
         }
-    } else if key == config.keybindings.navigation.up {
+    } else if key == &config.keybindings.navigation.up {
         if state.mode == Mode::Normal {
             navigation::go_up_or_down_in_data(state, value, Direction::Up);
         }
-    } else if key == config.keybindings.navigation.right {
+    } else if key == &config.keybindings.navigation.right {
         if state.mode == Mode::Normal {
             navigation::go_deeper_in_data(state, value);
         }
-    } else if key == config.keybindings.navigation.left {
+    } else if key == &config.keybindings.navigation.left {
         if state.mode == Mode::Normal {
             navigation::go_back_in_data(state);
         }
-    } else if key == config.keybindings.peek {
+    } else if key == &config.keybindings.peek {
         if state.mode == Mode::Normal {
             state.mode = Mode::Peeking;
         }
     }
 
     if state.mode == Mode::Peeking {
-        if key == config.keybindings.peeking.quit {
+        if key == &config.keybindings.peeking.quit {
             state.mode = Mode::Normal;
-        } else if key == config.keybindings.peeking.all {
+        } else if key == &config.keybindings.peeking.all {
             return Ok(TransitionResult {
                 exit: true,
                 result: Some(value.clone()),
             });
-        } else if key == config.keybindings.peeking.current {
+        } else if key == &config.keybindings.peeking.current {
             state.cell_path.members.pop();
             return Ok(TransitionResult {
                 exit: true,
@@ -179,7 +179,7 @@ fn transition_state(
                         .follow_cell_path(&state.cell_path.members, false)?,
                 ),
             });
-        } else if key == config.keybindings.peeking.under {
+        } else if key == &config.keybindings.peeking.under {
             return Ok(TransitionResult {
                 exit: true,
                 result: Some(

--- a/src/app.rs
+++ b/src/app.rs
@@ -110,7 +110,7 @@ pub(super) fn run(
     input: &Value,
     config: &Config,
 ) -> Result<Value> {
-    let mut state = State::from_value(&input);
+    let mut state = State::from_value(input);
 
     loop {
         terminal.draw(|frame| tui::render_ui(frame, input, &state, config))?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,7 +67,7 @@ impl Default for State {
 }
 
 impl State {
-    fn from_value(value: &Value) -> Self {
+    pub(super) fn from_value(value: &Value) -> Self {
         let mut state = Self::default();
         match value {
             Value::List { vals, .. } => state.cell_path.members.push(PathMember::Int {

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,18 +28,18 @@ pub(super) enum Mode {
     Peeking,
 }
 
-impl Mode {
-    fn default() -> Mode {
-        Mode::Normal
+impl Default for Mode {
+    fn default() -> Self {
+        Self::Normal
     }
 }
 
 impl std::fmt::Display for Mode {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let repr = match self {
-            Mode::Normal => "NORMAL",
-            Mode::Insert => "INSERT",
-            Mode::Peeking => "PEEKING",
+            Self::Normal => "NORMAL",
+            Self::Insert => "INSERT",
+            Self::Peeking => "PEEKING",
         };
         write!(f, "{}", repr)
     }
@@ -56,9 +56,9 @@ pub(super) struct State {
     pub mode: Mode,
 }
 
-impl State {
-    fn default() -> State {
-        State {
+impl Default for State {
+    fn default() -> Self {
+        Self {
             cell_path: CellPath { members: vec![] },
             bottom: false,
             mode: Mode::default(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use super::navigation::Direction;
 use super::{config::Config, navigation, tui};
 
 /// the mode in which the application is
-#[derive(PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(super) enum Mode {
     /// the NORMAL mode is the *navigation* mode, where the user can move around in the data
     Normal,
@@ -272,17 +272,22 @@ mod tests {
         ];
 
         for (key, expected_mode) in transitions {
+            let mode = state.mode.clone();
+
             let result = transition_state(&key, &config, &mut state, &value).unwrap();
+
             assert!(
                 !result.exit,
-                "unexpected exit after pressing {}",
-                repr_keycode(key)
+                "unexpected exit after pressing {} in {}",
+                repr_keycode(key),
+                mode,
             );
             assert!(
                 state.mode == expected_mode,
-                "expected to be in {} after pressing {}, found {}",
+                "expected to be in {} after pressing {} in {}, found {}",
                 expected_mode,
                 repr_keycode(key),
+                mode,
                 state.mode
             );
         }
@@ -306,20 +311,23 @@ mod tests {
         ];
 
         for (key, exit) in transitions {
+            let mode = state.mode.clone();
+
             let result = transition_state(key, &config, &mut state, &value).unwrap();
+
             if exit {
                 assert!(
                     result.exit,
                     "expected to quit after pressing {} in {} mode",
                     repr_keycode(key),
-                    state.mode
+                    mode
                 );
             } else {
                 assert!(
                     !result.exit,
                     "expected NOT to quit after pressing {} in {} mode",
                     repr_keycode(key),
-                    state.mode
+                    mode
                 );
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,4 +271,25 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn quit() {
+        /**/
+    }
+
+    #[test]
+    fn navigate_the_data() {
+        /**/
+    }
+
+    #[test]
+    fn peek_data() {
+        /**/
+    }
+
+    #[ignore = "data edition is not implemented for now"]
+    #[test]
+    fn edit_cells() {
+        /**/
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,7 @@ use parsing::{
 };
 
 /// the configuration for the status bar colors in all [`crate::app::Mode`]s
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct StatusBarColorConfig {
     pub normal: BgFgColorConfig,
     pub insert: BgFgColorConfig,
@@ -25,7 +25,7 @@ pub(super) struct StatusBarColorConfig {
 }
 
 /// the colors of the application
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct ColorConfig {
     /// the color when a row is NOT selected
     pub normal: BgFgColorConfig,
@@ -39,14 +39,14 @@ pub(super) struct ColorConfig {
 }
 
 /// a pair of background / foreground colors
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct BgFgColorConfig {
     pub background: Color,
     pub foreground: Color,
 }
 
 /// the bindings in NORMAL mode (see [crate::app::Mode::Normal])
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct NavigationBindingsMap {
     /// go one row up in the data
     pub up: Key,
@@ -59,7 +59,7 @@ pub(super) struct NavigationBindingsMap {
 }
 
 /// the bindings in PEEKING mode (see [crate::app::Mode::Peeking])
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct PeekingBindingsMap {
     /// peek the whole data structure
     pub all: Key,
@@ -71,7 +71,7 @@ pub(super) struct PeekingBindingsMap {
 }
 
 /// the keybindings mapping
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct KeyBindingsMap {
     pub quit: Key,
     /// go into INSERT mode (see [crate::app::Mode::Insert])
@@ -85,7 +85,7 @@ pub(super) struct KeyBindingsMap {
 }
 
 /// the layout of the application
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) enum Layout {
     /// show each row in a `[name, data, type]` column
     Table,
@@ -94,7 +94,7 @@ pub(super) enum Layout {
 }
 
 /// the configuration of the whole application
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct Config {
     pub colors: ColorConfig,
     pub keybindings: KeyBindingsMap,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,6 +17,7 @@ use parsing::{
 };
 
 /// the configuration for the status bar colors in all [`crate::app::Mode`]s
+#[derive(Clone)]
 pub(super) struct StatusBarColorConfig {
     pub normal: BgFgColorConfig,
     pub insert: BgFgColorConfig,
@@ -24,6 +25,7 @@ pub(super) struct StatusBarColorConfig {
 }
 
 /// the colors of the application
+#[derive(Clone)]
 pub(super) struct ColorConfig {
     /// the color when a row is NOT selected
     pub normal: BgFgColorConfig,
@@ -44,6 +46,7 @@ pub(super) struct BgFgColorConfig {
 }
 
 /// the bindings in NORMAL mode (see [crate::app::Mode::Normal])
+#[derive(Clone)]
 pub(super) struct NavigationBindingsMap {
     /// go one row up in the data
     pub up: Key,
@@ -56,6 +59,7 @@ pub(super) struct NavigationBindingsMap {
 }
 
 /// the bindings in PEEKING mode (see [crate::app::Mode::Peeking])
+#[derive(Clone)]
 pub(super) struct PeekingBindingsMap {
     /// peek the whole data structure
     pub all: Key,
@@ -67,6 +71,7 @@ pub(super) struct PeekingBindingsMap {
 }
 
 /// the keybindings mapping
+#[derive(Clone)]
 pub(super) struct KeyBindingsMap {
     pub quit: Key,
     /// go into INSERT mode (see [crate::app::Mode::Insert])
@@ -80,6 +85,7 @@ pub(super) struct KeyBindingsMap {
 }
 
 /// the layout of the application
+#[derive(Clone)]
 pub(super) enum Layout {
     /// show each row in a `[name, data, type]` column
     Table,
@@ -88,6 +94,7 @@ pub(super) enum Layout {
 }
 
 /// the configuration of the whole application
+#[derive(Clone)]
 pub(super) struct Config {
     pub colors: ColorConfig,
     pub keybindings: KeyBindingsMap,

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -129,6 +129,7 @@ pub(super) fn go_back_in_data(state: &mut State) {
     state.bottom = false;
 }
 
+// TODO: add proper assert error messages
 #[cfg(test)]
 mod tests {
     use nu_protocol::{ast::PathMember, Span, Value};

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -29,7 +29,7 @@ pub(super) fn go_up_or_down_in_data(state: &mut State, input: &Value, direction:
     }
 
     let direction = match direction {
-        Direction::Up => usize::MAX,
+        Direction::Up => -1,
         Direction::Down => 1,
     };
 
@@ -49,7 +49,10 @@ pub(super) fn go_up_or_down_in_data(state: &mut State, input: &Value, direction:
                     val: if vals.is_empty() {
                         val
                     } else {
-                        (val + direction + vals.len()) % vals.len()
+                        let len = vals.len() as i32;
+                        let new_index = (val as i32 + direction + len) % len;
+
+                        new_index as usize
                     },
                     span,
                     optional,
@@ -69,8 +72,11 @@ pub(super) fn go_up_or_down_in_data(state: &mut State, input: &Value, direction:
                     val: if cols.is_empty() {
                         "".into()
                     } else {
-                        let index = cols.iter().position(|x| x == &val).unwrap();
-                        cols[(index + direction + cols.len()) % cols.len()].clone()
+                        let index = cols.iter().position(|x| x == &val).unwrap() as i32;
+                        let len = cols.len() as i32;
+                        let new_index = (index + direction + len) % len;
+
+                        cols[new_index as usize].clone()
                     },
                     span,
                     optional,


### PR DESCRIPTION
## non-test commits
- fbcb3ab: *allow the Config to be cloned*
- 9be5ceb: *give a &Key to transition_state*
- ce401b7: *implement Default for Mode and State*
- 0770cca: *refactor the state initialization in `from_value`*
- ae3ed68: *fix overflow panic when moving in the data*
- df49a86: *make `State::from_value` public to super*
- 4c26453: *derive PartialEq and Debug for the whole config*

## TODO
- [x] `navigation.rs`: make sure the navigation in the data is ok
- [x] `app.rs`: make sure the application state machine works
- [x] `tui.rs`: make sure the rendering works as intended
- [x] `config/`: make sure the parsing of the config works
