### PR TITLE
use the latest stable revision of Nushell dependencies

### DIFF
--- a/.github/scripts/add-nu-dependencies.sh
+++ b/.github/scripts/add-nu-dependencies.sh
@@ -1,5 +1,0 @@
-nushell="/tmp/nushell"
-
-git clone https://github.com/nushell/nushell "$nushell"
-cargo add nu-plugin --path "$nushell/crates/nu-plugin"
-cargo add nu-protocol --path "$nushell/crates/nu-protocol" --features plugin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          cargo add "nu-plugin@${NU_VERSION}"
-          cargo add "nu-protocol@${NU_VERSION}" --features plugin
+          cargo add "nu-plugin@$NU_VERSION"
+          cargo add "nu-protocol@$NU_VERSION" --features plugin
 
       - name: Clippy
         run: cargo clippy --workspace -- $CLIPPY_OPTIONS
@@ -51,8 +51,8 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          cargo add "nu-plugin@${NU_VERSION}"
-          cargo add "nu-protocol@${NU_VERSION}" --features plugin
+          cargo add "nu-plugin@$NU_VERSION"
+          cargo add "nu-protocol@$NU_VERSION" --features plugin
 
       - name: Tests
         run: cargo test --workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cargo add "nu-plugin@$NU_VERSION"
           cargo add "nu-protocol@$NU_VERSION" --features plugin
+        shell: bash
 
       - name: Clippy
         run: cargo clippy --workspace -- $CLIPPY_OPTIONS
@@ -53,6 +54,7 @@ jobs:
         run: |
           cargo add "nu-plugin@$NU_VERSION"
           cargo add "nu-protocol@$NU_VERSION" --features plugin
+        shell: bash
 
       - name: Tests
         run: cargo test --workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,9 @@ jobs:
           rustflags: ""
 
       - name: Setup dependencies
-        run: bash .github/scripts/add-nu-dependencies.sh
+        run: |
+          cargo add "nu-plugin@${NU_VERSION}"
+          cargo add "nu-protocol@${NU_VERSION}" --features plugin
 
       - name: Tests
         run: cargo test --workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ name: continuous-integration
 
 env:
   CLIPPY_OPTIONS: "-D warnings"
+  NU_VERSION: "0.83.1"
 
 jobs:
   fmt-clippy:
@@ -25,7 +26,9 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Setup dependencies
-        run: bash .github/scripts/add-nu-dependencies.sh
+        run: |
+          cargo add "nu-plugin@${NU_VERSION}"
+          cargo add "nu-protocol@${NU_VERSION}" --features plugin
 
       - name: Clippy
         run: cargo clippy --workspace -- $CLIPPY_OPTIONS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ name = "nu_plugin_explore"
 anyhow = "1.0.73"
 console = "0.15.7"
 crossterm = "0.27.0"
+nu-plugin = { version = "0.83.1" }
+nu-protocol = { version = "0.83.1", features = ["plugin"] }
 ratatui = "0.22.0"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ bench = false
 [package]
 edition = "2021"
 name = "nu_plugin_explore"
-version = "0.83.2"
+version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A fast *interactive explorer* tool for *structured data* inspired by [`nu-explor
   - [*the idea behind an explorer*](#the-idea-behind-an-explorer)
   - [*why not `nu-explore`?*](#why-not-nu-explore)
 - [*installation*](#installation)
-  - [*setup the Nushell dependencies*](#setup-the-Nushell-dependencies)
   - [*install the plugin*](#install-the-plugin)
     - [*building from source*](#building-from-source)
     - [*installing manually*](#installing-manually)
@@ -37,34 +36,8 @@ will come very handy in a day-to-day basis for me at least :)
 so here we are... LET'S GO :muscle:
 
 # installation
-> **Note**  
-> the plugin has been written with the latest revision of [Nushell]
-
-## setup the Nushell dependencies
-as one can see in the [`Cargo.toml`](Cargo.toml) file, the [Nushell] dependencies are empty
-and need to be setup.  
-the reason is that the latest revision of [`nu-plugin`] and [`nu-protocol`] are not on [crates.io]
-
-to setup these dependencies, please download the source code of [Nushell], e.g.
-```nushell
-git clone https://github.com/nushell/nushell /path/to/nushell
-```
-
-> **Note**  
-> this is a little variable to make the following script simpler
-> ```nushell
-> let nushell: path = /path/to/nushell
-> ```
-
-finally run the following to setup the dependencies
-```nushell
-cargo add nu-plugin --path ($nushell | path join "crates" "nu-plugin")
-cargo add nu-protocol --path ($nushell | path join "crates" "nu-protocol") --features plugin
-```
-
 ## install the plugin
-now that the dependencies are all setup, we can install the plugin: there are threee ways to do it
-
+there are three ways to do it:
 ### building from source
 - build the plugin
 ```nushell

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ A fast *interactive explorer* tool for *structured data* inspired by [`nu-explor
   - [*the idea behind an explorer*](#the-idea-behind-an-explorer)
   - [*why not `nu-explore`?*](#why-not-nu-explore)
 - [*installation*](#installation)
-  - [*install the plugin*](#install-the-plugin)
-    - [*building from source*](#building-from-source)
-    - [*installing manually*](#installing-manually)
-    - [*using `nupm install`*](#using-nupm-install)
+  - [*building from source*](#building-from-source)
+  - [*installing manually*](#installing-manually)
+  - [*using `nupm install`*](#using-nupm-install)
 - [*usage*](#usage)
 - [*configuration*](#configuration)
 - [*see the documentation locally*](#see-the-documentation-locally)
@@ -36,9 +35,8 @@ will come very handy in a day-to-day basis for me at least :)
 so here we are... LET'S GO :muscle:
 
 # installation
-## install the plugin
 there are three ways to do it:
-### building from source
+## building from source
 - build the plugin
 ```nushell
 cargo build --release
@@ -49,7 +47,7 @@ register target/release/nu_plugin_explore
 ```
 - do not forget to restart [Nushell]
 
-### installing manually
+## installing manually
 - define the install root, e.g. `$env.CARGO_HOME` or `/some/where/plugins/`
 ```nushell
 let install_root: path = ...
@@ -64,7 +62,7 @@ nu --commands $"register ($install_root | path join "bin" $name)"
 ```
 - do not forget to restart [Nushell]
 
-### using `nupm install`
+## using `nupm install`
 > **Warning**  
 > this is a very alpha software and even requires to use the code from an unmerged PR :eyes:
 


### PR DESCRIPTION
this PR fixes the version of `nu-plugin` and `nu-protocol` to the latest stable release on *crates.io*: 0.83.1.

it also fixes the version of the plugin itself to 0.1.0 and updates the README.