### PR TITLE
give different colors to table columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ cargo doc --document-private-items --no-deps --open
 ## features
 - [x] support non-character bindings
 - [ ] when going into a file or URL, open it
-- [ ] give different colors to names and type
+- [x] give different colors to names and type
 - [ ] show true tables as such
 - [ ] get the config from `$env.config` => can parse configuration from CLI
 - [ ] add check for the config to make sure it's valid

--- a/examples/configuration/themes/dark.nuon
+++ b/examples/configuration/themes/dark.nuon
@@ -1,7 +1,17 @@
 {
     normal: {  # the colors for a normal row
-        background: reset, # "black" is not pure *black*
-        foreground: white,
+        name: {
+            background: reset, # "black" is not pure *black*
+            foreground: green,
+        },
+        data: {
+            background: reset, # "black" is not pure *black*
+            foreground: white,
+        },
+        shape: {
+            background: reset, # "black" is not pure *black*
+            foreground: red,
+        },
     },
     selected: {  # the colors for the row under the cursor
         background: white,

--- a/examples/configuration/themes/dark.nuon
+++ b/examples/configuration/themes/dark.nuon
@@ -10,7 +10,7 @@
         },
         shape: {
             background: reset, # "black" is not pure *black*
-            foreground: red,
+            foreground: blue,
         },
     },
     selected: {  # the colors for the row under the cursor

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -130,7 +130,7 @@ impl Config {
                     },
                     shape: BgFgColorConfig {
                         background: Color::Reset, // "Black" is not pure *black*
-                        foreground: Color::Red,
+                        foreground: Color::Blue,
                     },
                 },
                 selected: BgFgColorConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,11 +24,22 @@ pub(super) struct StatusBarColorConfig {
     pub peek: BgFgColorConfig,
 }
 
+/// the configuration for a row of the data rendering table
+#[derive(Clone, PartialEq, Debug)]
+pub(super) struct TableRowColorConfig {
+    // the name of the data, i.e. the key on the left
+    pub name: BgFgColorConfig,
+    // the data itself,
+    pub data: BgFgColorConfig,
+    // the type of the data, e.g. `string` or `int`
+    pub shape: BgFgColorConfig,
+}
+
 /// the colors of the application
 #[derive(Clone, PartialEq, Debug)]
 pub(super) struct ColorConfig {
     /// the color when a row is NOT selected
-    pub normal: BgFgColorConfig,
+    pub normal: TableRowColorConfig,
     /// the color when a row is selected
     pub selected: BgFgColorConfig,
     /// the modifier to apply to the row under the cursor
@@ -108,9 +119,19 @@ impl Config {
             show_cell_path: true,
             layout: Layout::Table,
             colors: ColorConfig {
-                normal: BgFgColorConfig {
-                    background: Color::Reset, // "Black" is not pure *black*
-                    foreground: Color::White,
+                normal: TableRowColorConfig {
+                    name: BgFgColorConfig {
+                        background: Color::Reset, // "Black" is not pure *black*
+                        foreground: Color::Green,
+                    },
+                    data: BgFgColorConfig {
+                        background: Color::Reset, // "Black" is not pure *black*
+                        foreground: Color::White,
+                    },
+                    shape: BgFgColorConfig {
+                        background: Color::Reset, // "Black" is not pure *black*
+                        foreground: Color::Red,
+                    },
                 },
                 selected: BgFgColorConfig {
                     background: Color::White,
@@ -178,12 +199,58 @@ impl Config {
                     for column in columns {
                         match column.as_str() {
                             "normal" => {
-                                if let Some(val) = try_fg_bg_colors(
+                                let (columns, span) = match follow_cell_path(
                                     &value,
                                     &["colors", "normal"],
-                                    &config.colors.normal,
-                                )? {
-                                    config.colors.normal = val
+                                )
+                                .unwrap()
+                                {
+                                    Value::Record { cols, span, .. } => (cols, span),
+                                    x => {
+                                        return Err(invalid_type(
+                                            &x,
+                                            &["colors", "normal"],
+                                            "record",
+                                        ))
+                                    }
+                                };
+
+                                for column in columns {
+                                    match column.as_str() {
+                                        "name" => {
+                                            if let Some(val) = try_fg_bg_colors(
+                                                &value,
+                                                &["colors", "normal", "name"],
+                                                &config.colors.normal.name,
+                                            )? {
+                                                config.colors.normal.name = val
+                                            }
+                                        }
+                                        "data" => {
+                                            if let Some(val) = try_fg_bg_colors(
+                                                &value,
+                                                &["colors", "normal", "data"],
+                                                &config.colors.normal.data,
+                                            )? {
+                                                config.colors.normal.data = val
+                                            }
+                                        }
+                                        "shape" => {
+                                            if let Some(val) = try_fg_bg_colors(
+                                                &value,
+                                                &["colors", "normal", "shape"],
+                                                &config.colors.normal.shape,
+                                            )? {
+                                                config.colors.normal.shape = val
+                                            }
+                                        }
+                                        x => {
+                                            return Err(invalid_field(
+                                                &["colors", "normal", x],
+                                                Some(span),
+                                            ))
+                                        }
+                                    }
                                 }
                             }
                             "selected" => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,6 +2,7 @@
 use ratatui::{
     prelude::{Alignment, Constraint, CrosstermBackend, Rect},
     style::Style,
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
     Frame,
 };
@@ -195,9 +196,6 @@ fn render_data(
     let mut data_path = state.cell_path.members.clone();
     let current = if !state.bottom { data_path.pop() } else { None };
 
-    let normal_style = Style::default()
-        .fg(config.colors.normal.data.foreground)
-        .bg(config.colors.normal.data.background);
     let highlight_style = Style::default()
         .fg(config.colors.selected.foreground)
         .bg(config.colors.selected.background)
@@ -221,7 +219,30 @@ fn render_data(
             let items: Vec<ListItem> = repr_data(data, &data_path, config)[0]
                 .clone()
                 .iter()
-                .map(|line| ListItem::new(line.clone()).style(normal_style))
+                .map(|_line| {
+                    ListItem::new(Line::from(vec![
+                        Span::styled(
+                            "name",
+                            Style::default()
+                                .fg(config.colors.normal.name.foreground)
+                                .bg(config.colors.normal.name.background),
+                        ),
+                        ": (".into(),
+                        Span::styled(
+                            "shape",
+                            Style::default()
+                                .fg(config.colors.normal.shape.foreground)
+                                .bg(config.colors.normal.shape.background),
+                        ),
+                        ") ".into(),
+                        Span::styled(
+                            "data",
+                            Style::default()
+                                .fg(config.colors.normal.data.foreground)
+                                .bg(config.colors.normal.data.background),
+                        ),
+                    ]))
+                })
                 .collect();
 
             let items = List::new(items)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,7 @@
 //! the module responsible for rendering the TUI
 use ratatui::{
     prelude::{Alignment, Constraint, CrosstermBackend, Rect},
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
     Frame,
 };
@@ -196,8 +196,8 @@ fn render_data(
     let current = if !state.bottom { data_path.pop() } else { None };
 
     let normal_style = Style::default()
-        .fg(config.colors.normal.foreground)
-        .bg(config.colors.normal.background);
+        .fg(config.colors.normal.data.foreground)
+        .bg(config.colors.normal.data.background);
     let highlight_style = Style::default()
         .fg(config.colors.selected.foreground)
         .bg(config.colors.selected.background)
@@ -239,12 +239,21 @@ fn render_data(
                 .iter()
                 .map(|row| {
                     Row::new(vec![
-                        Cell::from(row[0].clone())
-                            .style(Style::default().fg(Color::Green).bg(Color::Reset)),
-                        Cell::from(row[1].clone())
-                            .style(Style::default().fg(Color::Reset).bg(Color::Reset)),
-                        Cell::from(row[2].clone())
-                            .style(Style::default().fg(Color::Red).bg(Color::Reset)),
+                        Cell::from(row[0].clone()).style(
+                            Style::default()
+                                .fg(config.colors.normal.name.foreground)
+                                .bg(config.colors.normal.name.background),
+                        ),
+                        Cell::from(row[1].clone()).style(
+                            Style::default()
+                                .fg(config.colors.normal.data.foreground)
+                                .bg(config.colors.normal.data.background),
+                        ),
+                        Cell::from(row[2].clone()).style(
+                            Style::default()
+                                .fg(config.colors.normal.shape.foreground)
+                                .bg(config.colors.normal.shape.background),
+                        ),
                     ])
                 })
                 .collect();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,8 +1,8 @@
 //! the module responsible for rendering the TUI
 use ratatui::{
     prelude::{Alignment, Constraint, CrosstermBackend, Rect},
-    style::Style,
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Row, Table, TableState},
+    style::{Color, Style},
+    widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
     Frame,
 };
 
@@ -237,7 +237,16 @@ fn render_data(
         Layout::Table => {
             let rows: Vec<Row> = repr_data(data, &data_path, config)
                 .iter()
-                .map(|row| Row::new(row.clone()).style(normal_style))
+                .map(|row| {
+                    Row::new(vec![
+                        Cell::from(row[0].clone())
+                            .style(Style::default().fg(Color::Green).bg(Color::Reset)),
+                        Cell::from(row[1].clone())
+                            .style(Style::default().fg(Color::Reset).bg(Color::Reset)),
+                        Cell::from(row[2].clone())
+                            .style(Style::default().fg(Color::Red).bg(Color::Reset)),
+                    ])
+                })
                 .collect();
 
             let table = Table::new(rows)


### PR DESCRIPTION
this PR adds colors to the three line segments
- the name, data and shapes column have now different colors in the "table" layout
- the "name: (shape) data" lines of the "compact" layout have different colors, for the name, the shape and the data, just as in "table" layout but compacted

these colors can be changed through config :ok_hand: 