### PR TITLE
do not do anything with "exotic" events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -48,7 +48,7 @@ impl EventHandler {
                             CrosstermEvent::Key(e) => sender.send(Event::Key(e)),
                             CrosstermEvent::Mouse(e) => sender.send(Event::Mouse(e)),
                             CrosstermEvent::Resize(w, h) => sender.send(Event::Resize(w, h)),
-                            _ => unimplemented!(),
+                            _ => Ok(()),
                         }
                         .expect("failed to send terminal event")
                     }


### PR DESCRIPTION
this PR avoids crashing when losing / gaining focus and pasting into the application.