### PR TITLE
detect and render more "fuzzy" tables

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -272,7 +272,7 @@ mod tests {
         let mut app = App::from_value(value.clone());
 
         assert!(!app.is_at_bottom());
-        assert_eq!(app.position.members, to_path_member_vec(vec![PM::S("l")]));
+        assert_eq!(app.position.members, to_path_member_vec(&[PM::S("l")]));
 
         let transitions = vec![
             (nav.up, vec![PM::S("i")], false),
@@ -330,7 +330,7 @@ mod tests {
         ];
 
         for (key, cell_path, bottom) in transitions {
-            let expected = to_path_member_vec(cell_path);
+            let expected = to_path_member_vec(&cell_path);
             handle_key_events(KeyEvent::new(key, KeyModifiers::empty()), &mut app, &config)
                 .unwrap();
 

--- a/src/nu/cell_path.rs
+++ b/src/nu/cell_path.rs
@@ -8,7 +8,7 @@ pub(crate) enum PM<'a> {
     I(usize),
 }
 
-pub(crate) fn to_path_member_vec(cell_path: Vec<PM>) -> Vec<PathMember> {
+pub(crate) fn to_path_member_vec(cell_path: &[PM]) -> Vec<PathMember> {
     cell_path
         .iter()
         .map(|x| match *x {
@@ -24,4 +24,22 @@ pub(crate) fn to_path_member_vec(cell_path: Vec<PM>) -> Vec<PathMember> {
             },
         })
         .collect::<Vec<_>>()
+}
+
+impl<'a> PM<'a> {
+    pub(crate) fn as_cell_path(members: &[Self]) -> String {
+        format!(
+            "$.{}",
+            members
+                .iter()
+                .map(|m| {
+                    match m {
+                        Self::I(val) => val.to_string(),
+                        Self::S(val) => val.to_string(),
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join(".")
+        )
+    }
 }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -85,6 +85,10 @@ mod tests {
     use crate::nu::cell_path::{to_path_member_vec, PM};
     use nu_protocol::{ast::CellPath, record, Config, Value};
 
+    fn default_value_repr(value: &Value) -> String {
+        value.into_string(" ", &Config::default())
+    }
+
     #[test]
     fn value_mutation() {
         let list = Value::test_list(vec![
@@ -201,11 +205,20 @@ mod tests {
 
         for (value, members, cell, expected) in cases {
             let cell_path = CellPath {
-                members: to_path_member_vec(members),
+                members: to_path_member_vec(&members),
             };
 
-            // TODO: add proper error messages
-            assert_eq!(mutate_value_cell(&value, &cell_path, &cell), expected);
+            let result = mutate_value_cell(&value, &cell_path, &cell);
+            assert_eq!(
+                result,
+                expected,
+                "mutating {} at {:?} with {} should give {}, found {}",
+                default_value_repr(&value),
+                PM::as_cell_path(&members),
+                default_value_repr(&cell),
+                default_value_repr(&expected),
+                default_value_repr(&result)
+            );
         }
     }
 
@@ -225,7 +238,7 @@ mod tests {
             is_table(&table),
             true,
             "{} should be a table",
-            table.into_string(" ", &Config::default())
+            default_value_repr(&table)
         );
 
         let table_with_out_of_order_columns = Value::test_list(vec![
@@ -242,7 +255,7 @@ mod tests {
             is_table(&table_with_out_of_order_columns),
             true,
             "{} should be a table",
-            table_with_out_of_order_columns.into_string(" ", &Config::default())
+            default_value_repr(&table_with_out_of_order_columns)
         );
 
         let table_with_nulls = Value::test_list(vec![
@@ -259,7 +272,7 @@ mod tests {
             is_table(&table_with_nulls),
             true,
             "{} should be a table",
-            table_with_nulls.into_string(" ", &Config::default())
+            default_value_repr(&table_with_nulls)
         );
 
         let table_with_number_colum = Value::test_list(vec![
@@ -272,9 +285,11 @@ mod tests {
                 "b" => Value::test_float(2.34),
             }),
         ]);
-        assert_eq!(is_table(&table_with_number_colum), true,
+        assert_eq!(
+            is_table(&table_with_number_colum),
+            true,
             "{} should be a table",
-            table_with_number_colum.into_string(" ", &Config::default())
+            default_value_repr(&table_with_number_colum)
         );
 
         let not_a_table = Value::test_list(vec![
@@ -290,7 +305,7 @@ mod tests {
             is_table(&not_a_table),
             false,
             "{} should not be a table",
-            not_a_table.into_string(" ", &Config::default())
+            default_value_repr(&not_a_table)
         );
 
         assert_eq!(is_table(&Value::test_int(0)), false);

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -64,15 +64,15 @@ pub(crate) fn is_table(value: &Value) -> bool {
     match value {
         Value::List { vals, .. } => {
             if vals.is_empty() {
-                false
-            } else {
-                match vals[0] {
-                    Value::Record { .. } => {
-                        let first = vals[0].get_type().to_string();
-                        vals.iter().all(|v| v.get_type().to_string() == first)
-                    }
-                    _ => false,
+                return false;
+            }
+
+            match vals[0] {
+                Value::Record { .. } => {
+                    let first = vals[0].get_type().to_string();
+                    vals.iter().all(|v| v.get_type().to_string() == first)
                 }
+                _ => false,
             }
         }
         _ => false,

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -100,11 +100,10 @@ pub(crate) fn is_table(value: &Value) -> bool {
                                     if v.is_numeric() && ty.is_numeric() {
                                     } else if (!v.is_numeric() && ty.is_numeric())
                                         | (v.is_numeric() && !ty.is_numeric())
-                                    {
-                                        return false;
-                                    } else if v != ty {
                                         // NOTE: this might need a bit more work to include more
                                         // tables
+                                        | (v != ty)
+                                    {
                                         return false;
                                     }
                                 }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -83,7 +83,7 @@ pub(crate) fn is_table(value: &Value) -> bool {
 mod tests {
     use super::{is_table, mutate_value_cell};
     use crate::nu::cell_path::{to_path_member_vec, PM};
-    use nu_protocol::{ast::CellPath, record, Value};
+    use nu_protocol::{ast::CellPath, record, Config, Value};
 
     #[test]
     fn value_mutation() {
@@ -221,7 +221,12 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert_eq!(is_table(&table), true);
+        assert_eq!(
+            is_table(&table),
+            true,
+            "{} should be a table",
+            table.into_string(" ", &Config::default())
+        );
 
         let table_with_out_of_order_columns = Value::test_list(vec![
             Value::test_record(record! {
@@ -233,7 +238,12 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert_eq!(is_table(&table_with_out_of_order_columns), true);
+        assert_eq!(
+            is_table(&table_with_out_of_order_columns),
+            true,
+            "{} should be a table",
+            table_with_out_of_order_columns.into_string(" ", &Config::default())
+        );
 
         let table_with_nulls = Value::test_list(vec![
             Value::test_record(record! {
@@ -245,7 +255,12 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert_eq!(is_table(&table_with_nulls), true);
+        assert_eq!(
+            is_table(&table_with_nulls),
+            true,
+            "{} should be a table",
+            table_with_nulls.into_string(" ", &Config::default())
+        );
 
         let table_with_number_colum = Value::test_list(vec![
             Value::test_record(record! {
@@ -257,7 +272,10 @@ mod tests {
                 "b" => Value::test_float(2.34),
             }),
         ]);
-        assert_eq!(is_table(&table_with_number_colum), true);
+        assert_eq!(is_table(&table_with_number_colum), true,
+            "{} should be a table",
+            table_with_number_colum.into_string(" ", &Config::default())
+        );
 
         let not_a_table = Value::test_list(vec![
             Value::test_record(record! {
@@ -268,7 +286,12 @@ mod tests {
                 "b" => Value::test_int(1),
             }),
         ]);
-        assert_eq!(is_table(&not_a_table), false);
+        assert_eq!(
+            is_table(&not_a_table),
+            false,
+            "{} should not be a table",
+            not_a_table.into_string(" ", &Config::default())
+        );
 
         assert_eq!(is_table(&Value::test_int(0)), false);
     }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -333,7 +333,7 @@ mod tests {
             default_value_repr(&table_with_number_colum)
         );
 
-        let not_a_table = Value::test_list(vec![
+        let not_a_table_missing_field = Value::test_list(vec![
             Value::test_record(record! {
                 "a" => Value::test_string("a"),
             }),
@@ -343,10 +343,27 @@ mod tests {
             }),
         ]);
         assert_eq!(
-            is_table(&not_a_table),
+            is_table(&not_a_table_missing_field),
             false,
             "{} should not be a table",
-            default_value_repr(&not_a_table)
+            default_value_repr(&not_a_table_missing_field)
+        );
+
+        let not_a_table_incompatible_types = Value::test_list(vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("a"),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("a"),
+                "b" => Value::test_list(vec![Value::test_int(1)]),
+            }),
+        ]);
+        assert_eq!(
+            is_table(&not_a_table_incompatible_types),
+            false,
+            "{} should not be a table",
+            default_value_repr(&not_a_table_incompatible_types)
         );
 
         assert_eq!(is_table(&Value::test_int(0)), false);

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -213,15 +213,51 @@ mod tests {
     fn is_a_table() {
         let table = Value::test_list(vec![
             Value::test_record(record! {
-                "a" => Value::test_string("a"),
+                "a" => Value::test_string("foo"),
                 "b" => Value::test_int(1),
             }),
             Value::test_record(record! {
-                "a" => Value::test_string("a"),
-                "b" => Value::test_int(1),
+                "a" => Value::test_string("bar"),
+                "b" => Value::test_int(2),
             }),
         ]);
         assert_eq!(is_table(&table), true);
+
+        let table_with_out_of_order_columns = Value::test_list(vec![
+            Value::test_record(record! {
+                "b" => Value::test_int(1),
+                "a" => Value::test_string("foo"),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("bar"),
+                "b" => Value::test_int(2),
+            }),
+        ]);
+        assert_eq!(is_table(&table_with_out_of_order_columns), true);
+
+        let table_with_nulls = Value::test_list(vec![
+            Value::test_record(record! {
+                "a" => Value::test_nothing(),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("bar"),
+                "b" => Value::test_int(2),
+            }),
+        ]);
+        assert_eq!(is_table(&table_with_nulls), true);
+
+        let table_with_number_colum = Value::test_list(vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("foo"),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("bar"),
+                "b" => Value::test_float(2.34),
+            }),
+        ]);
+        assert_eq!(is_table(&table_with_number_colum), true);
 
         let not_a_table = Value::test_list(vec![
             Value::test_record(record! {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,7 +5,7 @@ use super::config::{repr_keycode, Layout};
 use super::{App, Config, Mode};
 use crossterm::event::KeyCode;
 use nu_protocol::ast::PathMember;
-use nu_protocol::Value;
+use nu_protocol::{Type, Value};
 use ratatui::prelude::Backend;
 use ratatui::{
     prelude::{Alignment, Constraint, Rect},
@@ -194,23 +194,34 @@ fn repr_data(data: &Value) -> Vec<DataRowRepr> {
 ///
 /// > see the tests for detailed examples
 fn repr_table(table: &[Value]) -> (Vec<String>, Vec<String>, Vec<Vec<String>>) {
-    let shapes = table[0]
-        .columns()
-        .iter()
-        .map(|c| table[0].get_data_by_key(c).unwrap().get_type().to_string())
-        .collect();
+    let columns = table[0].columns();
+    let mut shapes = vec![Type::Nothing; columns.len()];
 
-    let rows = table
-        .iter()
-        .map(|v| {
-            v.columns()
-                .iter()
-                .map(|c| repr_value(&v.get_data_by_key(c).unwrap()).data)
-                .collect::<Vec<String>>()
-        })
-        .collect::<Vec<Vec<String>>>();
+    let mut rows = vec![vec![]; table.len()];
 
-    (table[0].columns().to_vec(), shapes, rows)
+    for (i, row) in table.iter().enumerate() {
+        for (j, col) in columns.iter().enumerate() {
+            // NOTE: because `table` is a valid table, this should always be a `Some`
+            let val = row.get_data_by_key(col).unwrap();
+
+            let cell_type = val.get_type();
+            if !matches!(cell_type, Type::Nothing) {
+                if shapes[j].is_numeric() && cell_type.is_numeric() && (shapes[j] != cell_type) {
+                    shapes[j] = Type::Number;
+                } else {
+                    shapes[j] = cell_type;
+                }
+            }
+
+            rows[i].push(repr_value(&val).data);
+        }
+    }
+
+    (
+        columns.to_vec(),
+        shapes.iter().map(|s| s.to_string()).collect(),
+        rows,
+    )
 }
 
 /// render the whole data

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -750,7 +750,7 @@ mod tests {
         let expected = (
             vec!["b".into(), "a".into()],
             vec!["int".into(), "string".into()],
-            vec![vec!["2".into(), "y".into()], vec!["1".into(), "x".into()]],
+            vec![vec!["1".into(), "x".into()], vec!["2".into(), "y".into()]],
         );
 
         assert_eq!(repr_table(&table), expected);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -680,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn table() {
+    fn repr_simple_table() {
         let table = vec![
             Value::test_record(record! {
                 "a" => Value::test_string("x"),
@@ -696,6 +696,97 @@ mod tests {
             vec!["a".into(), "b".into()],
             vec!["string".into(), "int".into()],
             vec![vec!["x".into(), "1".into()], vec!["y".into(), "2".into()]],
+        );
+
+        assert_eq!(repr_table(&table), expected);
+    }
+
+    #[test]
+    fn repr_table_with_empty_column() {
+        let table = vec![
+            Value::test_record(record! {
+                "a" => Value::test_nothing(),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_nothing(),
+                "b" => Value::test_int(2),
+            }),
+        ];
+
+        let expected = (
+            vec!["a".into(), "b".into()],
+            vec!["nothing".into(), "int".into()],
+            vec![vec!["".into(), "1".into()], vec!["".into(), "2".into()]],
+        );
+
+        assert_eq!(repr_table(&table), expected);
+    }
+
+    #[test]
+    fn repr_table_with_shuffled_columns() {
+        let table = vec![
+            Value::test_record(record! {
+                "b" => Value::test_int(1),
+                "a" => Value::test_string("x"),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("y"),
+                "b" => Value::test_int(2),
+            }),
+        ];
+
+        let expected = (
+            vec!["b".into(), "a".into()],
+            vec!["int".into(), "string".into()],
+            vec![vec!["2".into(), "y".into()], vec!["1".into(), "x".into()]],
+        );
+
+        assert_eq!(repr_table(&table), expected);
+    }
+
+    #[test]
+    fn repr_table_with_holes() {
+        let table = vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("x"),
+                "b" => Value::test_nothing(),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_nothing(),
+                "b" => Value::test_int(2),
+            }),
+        ];
+
+        let expected = (
+            vec!["a".into(), "b".into()],
+            vec!["string".into(), "int".into()],
+            vec![vec!["x".into(), "".into()], vec!["".into(), "2".into()]],
+        );
+
+        assert_eq!(repr_table(&table), expected);
+    }
+
+    #[test]
+    fn repr_table_with_mixed_numeric_types() {
+        let table = vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("x"),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("y"),
+                "b" => Value::test_float(2.34),
+            }),
+        ];
+
+        let expected = (
+            vec!["a".into(), "b".into()],
+            vec!["string".into(), "number".into()],
+            vec![
+                vec!["x".into(), "1".into()],
+                vec!["y".into(), "2.34".into()],
+            ],
         );
 
         assert_eq!(repr_table(&table), expected);


### PR DESCRIPTION
should close #12 and more

## description
i think all the following should render as tables inside `explore`
- :heavy_check_mark: a normal full table
```nushell
> [{a: "foo", b: 1}, {a: "bar", b: 2}]
╭───┬─────┬───╮
│ # │  a  │ b │
├───┼─────┼───┤
│ 0 │ foo │ 1 │
│ 1 │ bar │ 2 │
╰───┴─────┴───╯
```
- :x: the same table with mixed columns
```nushell
> [{a: "foo", b: 1}, {b: 2, a: "bar"}]
╭───┬─────┬───╮
│ # │  a  │ b │
├───┼─────┼───┤
│ 0 │ foo │ 1 │
│ 1 │ bar │ 2 │
╰───┴─────┴───╯
```
- :x: `null` in the first column
```nushell
> [{a: null, b: 1}, {a: "bar", b: 2}]
╭───┬─────┬───╮
│ # │  a  │ b │
├───┼─────┼───┤
│ 0 │     │ 1 │
│ 1 │ bar │ 2 │
╰───┴─────┴───╯
```
- :x: `null` in the second column
```nushell
> [{a: "foo", b: 1}, {a: "bar", b: null}]
╭───┬─────┬───╮
│ # │  a  │ b │
├───┼─────┼───┤
│ 0 │ foo │ 1 │
│ 1 │ bar │   │
╰───┴─────┴───╯
```
- :x: different numeric types
```nushell
> [{a: "foo", b: 1}, {a: "bar", b: 2.34}]
╭───┬─────┬──────╮
│ # │  a  │  b   │
├───┼─────┼──────┤
│ 0 │ foo │    1 │
│ 1 │ bar │ 2.34 │
╰───┴─────┴──────╯
```

## try it out
run
```nushell
[{a: "foo", b: 1}, {a: "bar", b: 2}] | ex
[{a: "foo", b: 1}, {b: 2, a: "bar"}] | ex
[{a: null, b: 1}, {a: "bar", b: 2}] | ex
[{a: "foo", b: 1}, {a: "bar", b: null}] | ex
[{a: "foo", b: 1}, {a: "bar", b: 2.34}] | ex
```

### before
only the first one renders

### after
they all render as tables, regardless of `nulls`, similar numeric types and out of order columns