### PR TITLE
add support from table / record transposition

### DIFF
--- a/examples/config/default.nuon
+++ b/examples/config/default.nuon
@@ -72,5 +72,6 @@
             under: 'p',  # peek only what's under the cursor
             view: 'v',  # peek the current view, i.e. what is visible
         },
+        tranpose: 't',  # tranpose the data if it's a table or a record, this is an *involution*
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,7 @@ pub struct KeyBindingsMap {
     /// go into PEEKING mode (see [crate::app::Mode::Peeking])
     pub peek: KeyCode,
     pub peeking: PeekingBindingsMap,
+    pub transpose: KeyCode,
 }
 
 /// the layout of the application
@@ -200,6 +201,7 @@ impl Default for Config {
                     under: KeyCode::Char('p'),
                     view: KeyCode::Char('v'),
                 },
+                transpose: KeyCode::Char('t'),
             },
         }
     }
@@ -556,6 +558,11 @@ impl Config {
                                             ));
                                         }
                                     }
+                                }
+                            }
+                            "transpose" => {
+                                if let Some(val) = try_key(&value, &["keybindings", "tranpose"])? {
+                                    config.keybindings.transpose = val
                                 }
                             }
                             x => return Err(invalid_field(&["keybindings", x], Some(cell.span()))),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -60,7 +60,8 @@ pub fn handle_key_events(
             } else if key_event.code == config.keybindings.transpose {
                 let mut path = app.position.clone();
                 path.members.pop();
-                return Ok(TransitionResult::Edit(transpose(&app.value), path));
+                let view = app.value.clone().follow_cell_path(&path.members, false)?;
+                return Ok(TransitionResult::Edit(transpose(&view), path));
             }
         }
         Mode::Insert => {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -15,7 +15,7 @@ pub enum TransitionResult {
     Quit,
     Continue,
     Return(Value),
-    Edit(Value, CellPath),
+    Mutate(Value, CellPath),
     Error(String),
 }
 
@@ -61,7 +61,7 @@ pub fn handle_key_events(
                 let mut path = app.position.clone();
                 path.members.pop();
                 let view = app.value.clone().follow_cell_path(&path.members, false)?;
-                return Ok(TransitionResult::Edit(transpose(&view), path));
+                return Ok(TransitionResult::Mutate(transpose(&view), path));
             }
         }
         Mode::Insert => {
@@ -73,7 +73,7 @@ pub fn handle_key_events(
             match app.editor.handle_key(&key_event.code) {
                 Some(Some(v)) => {
                     app.mode = Mode::Normal;
-                    return Ok(TransitionResult::Edit(v, app.position.clone()));
+                    return Ok(TransitionResult::Mutate(v, app.position.clone()));
                 }
                 Some(None) => {
                     app.mode = Mode::Normal;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,6 +6,7 @@ use crate::{
     app::{App, Mode},
     config::Config,
     navigation::{self, Direction},
+    nu::value::transpose,
 };
 
 /// the result of a state transition
@@ -56,6 +57,8 @@ pub fn handle_key_events(
             } else if key_event.code == config.keybindings.navigation.left {
                 navigation::go_back_in_data(app);
                 return Ok(TransitionResult::Continue);
+            } else if key_event.code == config.keybindings.transpose {
+                return Ok(TransitionResult::Edit(transpose(&app.value)));
             }
         }
         Mode::Insert => {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -528,4 +528,53 @@ mod tests {
         ];
         run_peeking_scenario(peek_at_the_bottom, &config, value);
     }
+
+    #[test]
+    fn transpose_the_data() {
+        let config = Config::default();
+        let kmap = config.clone().keybindings;
+
+        let value = Value::test_record(record!(
+            "a" => Value::test_int(1),
+            "b" => Value::test_int(2),
+            "c" => Value::test_int(3),
+        ));
+        let mut app = App::from_value(value.clone());
+
+        assert!(!app.is_at_bottom());
+        assert_eq!(app.position.members, to_path_member_vec(&[PM::S("a")]));
+
+        let transitions = vec![
+            (kmap.navigation.down, vec![PM::S("b")]),
+            (kmap.transpose, vec![PM::I(0)]),
+            (kmap.navigation.up, vec![PM::I(2)]),
+            (kmap.transpose, vec![PM::S("a")]),
+        ];
+
+        for (key, cell_path) in transitions {
+            let expected = to_path_member_vec(&cell_path);
+            match handle_key_events(KeyEvent::new(key, KeyModifiers::empty()), &mut app, &config)
+                .unwrap()
+            {
+                TransitionResult::Mutate(cell, path) => {
+                    app.value = crate::nu::value::mutate_value_cell(&app.value, &path, &cell)
+                }
+                _ => {}
+            }
+
+            assert!(
+                !app.is_at_bottom(),
+                "expected NOT to be at the bottom after pressing {}",
+                repr_keycode(&key)
+            );
+
+            assert_eq!(
+                app.position.members,
+                expected,
+                "expected to be at {:?}, found {:?}",
+                repr_path_member_vec(&expected),
+                repr_path_member_vec(&app.position.members)
+            );
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,9 @@ pub fn explore(call: &EvaluatedCall, input: Value) -> Result<Value> {
                     match handle_key_events(key_event, &mut app, &config)? {
                         TransitionResult::Quit => break,
                         TransitionResult::Continue => {}
-                        TransitionResult::Edit(cell, path) => {
-                            app.value = crate::nu::value::mutate_value_cell(&app.value, &path, &cell)
+                        TransitionResult::Mutate(cell, path) => {
+                            app.value =
+                                crate::nu::value::mutate_value_cell(&app.value, &path, &cell)
                         }
                         TransitionResult::Error(error) => {
                             tui.draw(&mut app, &config, Some(&error))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,8 @@ pub fn explore(call: &EvaluatedCall, input: Value) -> Result<Value> {
                     match handle_key_events(key_event, &mut app, &config)? {
                         TransitionResult::Quit => break,
                         TransitionResult::Continue => {}
-                        TransitionResult::Edit(cell) => {
-                            app.value = crate::nu::value::mutate_value_cell(
-                                &app.value,
-                                &app.position,
-                                &cell,
-                            )
+                        TransitionResult::Edit(cell, path) => {
+                            app.value = crate::nu::value::mutate_value_cell(&app.value, &path, &cell)
                         }
                         TransitionResult::Error(error) => {
                             tui.draw(&mut app, &config, Some(&error))?;

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -155,7 +155,7 @@ pub(crate) fn transpose(value: &Value) -> Value {
             _ => return value.clone(),
         };
 
-        let foo = (1..(rows[0].columns().len()))
+        let foo = (1..=(rows[0].columns().len()))
             .map(|i| format!("{i}"))
             .collect::<Vec<String>>();
 

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -149,7 +149,7 @@ pub(crate) fn is_table(value: &Value) -> bool {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
-    value.clone()
+    Value::string("this cell has been transposed", value.span())
 }
 
 #[cfg(test)]

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -182,7 +182,25 @@ pub(crate) fn transpose(value: &Value) -> Value {
             }
         }
 
-        return value.clone();
+        match value {
+            Value::List { vals, .. } => {
+                let mut rows = vec![];
+                for col in vals[0].columns() {
+                    let mut cols = vec!["1".into()];
+                    let mut vs = vec![Value::string(col, Span::unknown())];
+
+                    for (i, v) in vals.iter().enumerate() {
+                        cols.push(format!("{}", i + 2));
+                        vs.push(v.get_data_by_key(col).unwrap());
+                    }
+
+                    rows.push(Value::record(Record { cols, vals: vs }, Span::unknown()));
+                }
+
+                return Value::list(rows, Span::unknown());
+            }
+            _ => return value.clone(),
+        }
     }
 
     match value {

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -149,6 +149,22 @@ pub(crate) fn is_table(value: &Value) -> bool {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
+    if value.columns()
+        == &(1..(value.columns().len()))
+            .map(|i| format!("{i}"))
+            .collect::<Vec<String>>()
+    {
+        if value.columns().len() == 2 {
+            return value.clone();
+        } else {
+            return value.clone();
+        }
+    }
+
+    if is_table(value) {
+        return value.clone();
+    }
+
     match value {
         Value::Record { val: rec, .. } => {
             let mut rows = vec![];

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -178,7 +178,31 @@ pub(crate) fn transpose(value: &Value) -> Value {
                     _ => return value.clone(),
                 }
             } else {
-                return value.clone();
+                match value {
+                    Value::List { vals, .. } => {
+                        let mut rows = vec![];
+                        let cols: Vec<String> = vals
+                            .iter()
+                            .map(|v| v.get_data_by_key("1").unwrap().as_string().unwrap())
+                            .collect();
+
+                        for i in 0..(vals[0].columns().len() - 1) {
+                            rows.push(Value::record(
+                                Record {
+                                    cols: cols.clone(),
+                                    vals: vals
+                                        .iter()
+                                        .map(|v| v.get_data_by_key(&format!("{}", i + 2)).unwrap())
+                                        .collect(),
+                                },
+                                Span::unknown(),
+                            ));
+                        }
+
+                        return Value::list(rows, Span::unknown());
+                    }
+                    _ => return value.clone(),
+                }
             }
         }
 

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -150,7 +150,7 @@ pub(crate) fn is_table(value: &Value) -> bool {
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
     if value.columns()
-        == &(1..(value.columns().len()))
+        == (1..(value.columns().len()))
             .map(|i| format!("{i}"))
             .collect::<Vec<String>>()
     {

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -155,11 +155,11 @@ pub(crate) fn transpose(value: &Value) -> Value {
             _ => return value.clone(),
         };
 
-        let foo = (1..=(rows[0].columns().len()))
+        let full_columns = (1..=(rows[0].columns().len()))
             .map(|i| format!("{i}"))
             .collect::<Vec<String>>();
 
-        if rows[0].columns() == foo {
+        if rows[0].columns() == full_columns {
             if rows[0].columns().len() == 2 {
                 match value {
                     Value::List { vals: rows, .. } => {

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -575,5 +575,18 @@ mod tests {
             default_value_repr(&table),
             default_value_repr(&result)
         );
+
+        assert_eq!(
+            transpose(&Value::test_string("foo")),
+            Value::test_string("foo")
+        );
+
+        assert_eq!(
+            transpose(&Value::test_list(vec![
+                Value::test_int(1),
+                Value::test_int(2)
+            ])),
+            Value::test_list(vec![Value::test_int(1), Value::test_int(2)])
+        );
     }
 }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use nu_protocol::{
     ast::{CellPath, PathMember},
-    Record, Span, Type, Value,
+    record, Record, Span, Type, Value,
 };
 
 pub(crate) fn mutate_value_cell(value: &Value, cell_path: &CellPath, cell: &Value) -> Value {
@@ -149,7 +149,23 @@ pub(crate) fn is_table(value: &Value) -> bool {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
-    Value::string("this cell has been transposed", value.span())
+    match value {
+        Value::Record { val: rec, .. } => {
+            let mut rows = vec![];
+            for (col, val) in rec.iter() {
+                rows.push(Value::record(
+                    record! {
+                        "1" => Value::string(col, Span::unknown()),
+                        "2" => val.clone(),
+                    },
+                    Span::unknown(),
+                ));
+            }
+
+            Value::list(rows, Span::unknown())
+        }
+        _ => value.clone(),
+    }
 }
 
 #[cfg(test)]

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -452,9 +452,25 @@ mod tests {
                 "2" => Value::test_int(2),
             }),
         ]);
-        assert_eq!(transpose(&record), expected);
+        let result = transpose(&record);
+        assert_eq!(
+            result,
+            expected,
+            "transposing {} should give {}, found {}",
+            default_value_repr(&record),
+            default_value_repr(&expected),
+            default_value_repr(&result)
+        );
         // make sure `transpose` is an *involution*
-        assert_eq!(transpose(&expected), record);
+        let result = transpose(&expected);
+        assert_eq!(
+            result,
+            record,
+            "transposing {} should give {}, found {}",
+            default_value_repr(&expected),
+            default_value_repr(&record),
+            default_value_repr(&result)
+        );
 
         let table = Value::test_list(vec![
             Value::test_record(record! {
@@ -478,8 +494,24 @@ mod tests {
                 "3" => Value::test_int(4),
             }),
         ]);
-        assert_eq!(transpose(&table), expected);
+        let result = transpose(&table);
+        assert_eq!(
+            result,
+            expected,
+            "transposing {} should give {}, found {}",
+            default_value_repr(&table),
+            default_value_repr(&expected),
+            default_value_repr(&result)
+        );
         // make sure `transpose` is an *involution*
-        assert_eq!(transpose(&expected), table);
+        let result = transpose(&expected);
+        assert_eq!(
+            result,
+            table,
+            "transposing {} should give {}, found {}",
+            default_value_repr(&expected),
+            default_value_repr(&table),
+            default_value_repr(&result)
+        );
     }
 }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -149,19 +149,39 @@ pub(crate) fn is_table(value: &Value) -> bool {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
-    if value.columns()
-        == (1..(value.columns().len()))
-            .map(|i| format!("{i}"))
-            .collect::<Vec<String>>()
-    {
-        if value.columns().len() == 2 {
-            return value.clone();
-        } else {
-            return value.clone();
-        }
-    }
-
     if is_table(value) {
+        let rows = match value {
+            Value::List { vals, .. } => vals,
+            _ => return value.clone(),
+        };
+
+        let foo = (1..(rows[0].columns().len()))
+            .map(|i| format!("{i}"))
+            .collect::<Vec<String>>();
+
+        if rows[0].columns() == foo {
+            if rows[0].columns().len() == 2 {
+                match value {
+                    Value::List { vals: rows, .. } => {
+                        let cols: Vec<String> = rows
+                            .iter()
+                            .map(|row| row.get_data_by_key("1").unwrap().as_string().unwrap())
+                            .collect();
+
+                        let vals: Vec<Value> = rows
+                            .iter()
+                            .map(|row| row.get_data_by_key("2").unwrap())
+                            .collect();
+
+                        return Value::record(Record { cols, vals }, Span::unknown());
+                    }
+                    _ => return value.clone(),
+                }
+            } else {
+                return value.clone();
+            }
+        }
+
         return value.clone();
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -538,7 +538,7 @@ fn render_status_bar<B: Backend>(frame: &mut Frame<'_, B>, app: &App, config: &C
 
     let hints = match app.mode {
         Mode::Normal => format!(
-            "{} to {} | {}{}{}{} to move around | {} to peek | {} to quit",
+            "{} to {} | {}{}{}{} to move around | {} to peek | {} to transpose | {} to quit",
             repr_keycode(&config.keybindings.insert),
             Mode::Insert,
             repr_keycode(&config.keybindings.navigation.left),
@@ -546,6 +546,7 @@ fn render_status_bar<B: Backend>(frame: &mut Frame<'_, B>, app: &App, config: &C
             repr_keycode(&config.keybindings.navigation.up),
             repr_keycode(&config.keybindings.navigation.right),
             repr_keycode(&config.keybindings.peek),
+            repr_keycode(&config.keybindings.transpose),
             repr_keycode(&config.keybindings.quit),
         ),
         Mode::Insert => format!(


### PR DESCRIPTION
this PR adds the ability to tranpose the current view, if it's a table or a record, just as the built-in `transpose` command does.

the default binding is `t`.

the transposition is an *involution*, i.e. it is its self inverse, meaning that applying the tranposition twice give you back the original data.