### PR TITLE
add a warning when a near-table is detected

### DIFF
--- a/examples/config/default.nuon
+++ b/examples/config/default.nuon
@@ -54,6 +54,10 @@
                 foreground: white,
             },
         },
+        warning: {
+            foreground: red,
+            background: yellow,
+        }
     }
     keybindings: {
         quit: 'q',  # quit `explore`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,8 @@ pub struct ColorConfig {
     pub status_bar: StatusBarColorConfig,
     /// the color when editing a cell
     pub editor: EditorColorConfig,
+    /// the color of a warning banner
+    pub warning: BgFgColorConfig,
 }
 
 /// a pair of background / foreground colors
@@ -181,6 +183,10 @@ impl Default for Config {
                         background: Color::Reset,
                         foreground: Color::White,
                     },
+                },
+                warning: BgFgColorConfig {
+                    background: Color::Yellow,
+                    foreground: Color::Red,
                 },
             },
             keybindings: KeyBindingsMap {
@@ -417,6 +423,15 @@ impl Config {
                                             ))
                                         }
                                     }
+                                }
+                            }
+                            "warning" => {
+                                if let Some(val) = try_fg_bg_colors(
+                                    &value,
+                                    &["colors", "warning"],
+                                    &config.colors.warning,
+                                )? {
+                                    config.colors.warning = val
                                 }
                             }
                             x => return Err(invalid_field(&["colors", x], cell.span())),

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -5,6 +5,17 @@ use nu_protocol::{
     record, Record, Span, Type, Value,
 };
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum Table {
+    Empty,
+    RowNotARecord(usize, Type),
+    RowIncompatibleLen(usize, usize, usize),
+    RowIncompatibleType(usize, String, Type, Type),
+    RowInvalidKey(usize, String, Vec<String>),
+    IsTable,
+    NotAList,
+}
+
 pub(crate) fn mutate_value_cell(value: &Value, cell_path: &CellPath, cell: &Value) -> Value {
     if cell_path.members.is_empty() {
         return cell.clone();

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -529,6 +529,39 @@ mod tests {
         );
 
         assert_eq!(is_table(&Value::test_int(0)), Table::NotAList);
+
+        assert_eq!(is_table(&Value::test_list(vec![])), Table::Empty);
+
+        let not_a_table_row_not_record = Value::test_list(vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("a"),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_int(0),
+        ]);
+        assert_eq!(
+            is_table(&not_a_table_row_not_record),
+            Table::RowNotARecord(1, Type::Int),
+            "{} should not be a table",
+            default_value_repr(&not_a_table_row_not_record)
+        );
+
+        let not_a_table_row_invalid_key = Value::test_list(vec![
+            Value::test_record(record! {
+                "a" => Value::test_string("a"),
+                "b" => Value::test_int(1),
+            }),
+            Value::test_record(record! {
+                "a" => Value::test_string("a"),
+                "c" => Value::test_int(2),
+            }),
+        ]);
+        assert_eq!(
+            is_table(&not_a_table_row_invalid_key),
+            Table::RowInvalidKey(1, "b".into(), vec!["a".into(), "c".into()]),
+            "{} should not be a table",
+            default_value_repr(&not_a_table_row_invalid_key)
+        );
     }
 
     #[test]

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -135,11 +135,9 @@ pub(crate) fn is_table(value: &Value) -> Table {
                             }
                         },
                         None => {
-                            return Table::RowInvalidKey(
-                                i + 1,
-                                key.clone(),
-                                row.keys().cloned().collect(),
-                            )
+                            let mut keys = row.keys().cloned().collect::<Vec<String>>();
+                            keys.sort();
+                            return Table::RowInvalidKey(i + 1, key.clone(), keys);
                         }
                     }
                 }

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -180,7 +180,7 @@ pub(crate) fn is_table(value: &Value) -> Table {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
-    if is_table(value) {
+    if matches!(is_table(value), Table::IsTable) {
         let value_rows = match value {
             Value::List { vals, .. } => vals,
             _ => return value.clone(),
@@ -279,7 +279,7 @@ mod tests {
     use super::{is_table, mutate_value_cell};
     use crate::nu::{
         cell_path::{to_path_member_vec, PM},
-        value::transpose,
+        value::{transpose, Table},
     };
     use nu_protocol::{ast::CellPath, record, Config, Value};
 
@@ -434,6 +434,7 @@ mod tests {
         ]);
         assert!(
             is_table(&table),
+            Table::IsTable,
             "{} should be a table",
             default_value_repr(&table)
         );
@@ -450,6 +451,7 @@ mod tests {
         ]);
         assert!(
             is_table(&table_with_out_of_order_columns),
+            Table::IsTable,
             "{} should be a table",
             default_value_repr(&table_with_out_of_order_columns)
         );
@@ -466,6 +468,7 @@ mod tests {
         ]);
         assert!(
             is_table(&table_with_nulls),
+            Table::IsTable,
             "{} should be a table",
             default_value_repr(&table_with_nulls)
         );
@@ -482,6 +485,7 @@ mod tests {
         ]);
         assert!(
             is_table(&table_with_number_colum),
+            Table::IsTable,
             "{} should be a table",
             default_value_repr(&table_with_number_colum)
         );
@@ -495,8 +499,9 @@ mod tests {
                 "b" => Value::test_int(1),
             }),
         ]);
-        assert!(
-            !is_table(&not_a_table_missing_field),
+        assert_ne!(
+            is_table(&not_a_table_missing_field),
+            Table::IsTable,
             "{} should not be a table",
             default_value_repr(&not_a_table_missing_field)
         );
@@ -511,13 +516,14 @@ mod tests {
                 "b" => Value::test_list(vec![Value::test_int(1)]),
             }),
         ]);
-        assert!(
-            !is_table(&not_a_table_incompatible_types),
+        assert_ne!(
+            is_table(&not_a_table_incompatible_types),
+            Table::IsTable,
             "{} should not be a table",
             default_value_repr(&not_a_table_incompatible_types)
         );
 
-        assert!(!is_table(&Value::test_int(0)));
+        assert_ne!(is_table(&Value::test_int(0)), Table::IsTable);
     }
 
     #[test]

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -281,7 +281,7 @@ mod tests {
         cell_path::{to_path_member_vec, PM},
         value::{transpose, Table},
     };
-    use nu_protocol::{ast::CellPath, record, Config, Value};
+    use nu_protocol::{ast::CellPath, record, Config, Type, Value};
 
     fn default_value_repr(value: &Value) -> String {
         value.to_expanded_string(" ", &Config::default())
@@ -432,7 +432,7 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert!(
+        assert_eq!(
             is_table(&table),
             Table::IsTable,
             "{} should be a table",
@@ -449,7 +449,7 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert!(
+        assert_eq!(
             is_table(&table_with_out_of_order_columns),
             Table::IsTable,
             "{} should be a table",
@@ -466,7 +466,7 @@ mod tests {
                 "b" => Value::test_int(2),
             }),
         ]);
-        assert!(
+        assert_eq!(
             is_table(&table_with_nulls),
             Table::IsTable,
             "{} should be a table",
@@ -483,7 +483,7 @@ mod tests {
                 "b" => Value::test_float(2.34),
             }),
         ]);
-        assert!(
+        assert_eq!(
             is_table(&table_with_number_colum),
             Table::IsTable,
             "{} should be a table",
@@ -499,9 +499,9 @@ mod tests {
                 "b" => Value::test_int(1),
             }),
         ]);
-        assert_ne!(
+        assert_eq!(
             is_table(&not_a_table_missing_field),
-            Table::IsTable,
+            Table::RowIncompatibleLen(1, 2, 1),
             "{} should not be a table",
             default_value_repr(&not_a_table_missing_field)
         );
@@ -516,14 +516,19 @@ mod tests {
                 "b" => Value::test_list(vec![Value::test_int(1)]),
             }),
         ]);
-        assert_ne!(
+        assert_eq!(
             is_table(&not_a_table_incompatible_types),
-            Table::IsTable,
+            Table::RowIncompatibleType(
+                1,
+                "b".to_string(),
+                Type::List(Box::new(Type::Int)),
+                Type::Int
+            ),
             "{} should not be a table",
             default_value_repr(&not_a_table_incompatible_types)
         );
 
-        assert_ne!(is_table(&Value::test_int(0)), Table::IsTable);
+        assert_eq!(is_table(&Value::test_int(0)), Table::NotAList);
     }
 
     #[test]

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -12,7 +12,7 @@ pub(crate) enum Table {
     RowIncompatibleLen(usize, usize, usize),
     RowIncompatibleType(usize, String, Type, Type),
     RowInvalidKey(usize, String, Vec<String>),
-    IsTable,
+    IsValid,
     NotAList,
 }
 
@@ -143,7 +143,7 @@ pub(crate) fn is_table(value: &Value) -> Table {
                 }
             }
 
-            Table::IsTable
+            Table::IsValid
         }
         _ => Table::NotAList,
     }
@@ -178,7 +178,7 @@ pub(crate) fn is_table(value: &Value) -> Table {
 /// }
 /// ```
 pub(crate) fn transpose(value: &Value) -> Value {
-    if matches!(is_table(value), Table::IsTable) {
+    if matches!(is_table(value), Table::IsValid) {
         let value_rows = match value {
             Value::List { vals, .. } => vals,
             _ => return value.clone(),
@@ -432,7 +432,7 @@ mod tests {
         ]);
         assert_eq!(
             is_table(&table),
-            Table::IsTable,
+            Table::IsValid,
             "{} should be a table",
             default_value_repr(&table)
         );
@@ -449,7 +449,7 @@ mod tests {
         ]);
         assert_eq!(
             is_table(&table_with_out_of_order_columns),
-            Table::IsTable,
+            Table::IsValid,
             "{} should be a table",
             default_value_repr(&table_with_out_of_order_columns)
         );
@@ -466,7 +466,7 @@ mod tests {
         ]);
         assert_eq!(
             is_table(&table_with_nulls),
-            Table::IsTable,
+            Table::IsValid,
             "{} should be a table",
             default_value_repr(&table_with_nulls)
         );
@@ -483,7 +483,7 @@ mod tests {
         ]);
         assert_eq!(
             is_table(&table_with_number_colum),
-            Table::IsTable,
+            Table::IsValid,
             "{} should be a table",
             default_value_repr(&table_with_number_colum)
         );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -245,7 +245,7 @@ fn render_data(frame: &mut Frame, app: &App, config: &Config) {
         });
 
     let table_type = is_table(&value);
-    let is_a_table = matches!(table_type, crate::nu::value::Table::IsTable);
+    let is_a_table = matches!(table_type, crate::nu::value::Table::IsValid);
 
     let mut data_frame_height = if config.show_cell_path {
         frame.size().height - 2
@@ -271,19 +271,17 @@ fn render_data(frame: &mut Frame, app: &App, config: &Config) {
                 i, k, ks
             )),
             crate::nu::value::Table::NotAList => None,
-            crate::nu::value::Table::IsTable => unreachable!(),
+            crate::nu::value::Table::IsValid => unreachable!(),
         };
 
-        if msg.is_some() {
+        if let Some(msg) = msg {
             data_frame_height -= 1;
             frame.render_widget(
-                Paragraph::new(msg.unwrap())
-                    .alignment(Alignment::Right)
-                    .style(
-                        Style::default()
-                            .bg(config.colors.warning.background)
-                            .fg(config.colors.warning.foreground),
-                    ),
+                Paragraph::new(msg).alignment(Alignment::Right).style(
+                    Style::default()
+                        .bg(config.colors.warning.background)
+                        .fg(config.colors.warning.foreground),
+                ),
                 Rect::new(0, data_frame_height, frame.size().width, 1),
             );
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -279,7 +279,11 @@ fn render_data(frame: &mut Frame, app: &App, config: &Config) {
             frame.render_widget(
                 Paragraph::new(msg.unwrap())
                     .alignment(Alignment::Right)
-                    .style(Style::default().bg(Color::Yellow).fg(Color::Red)),
+                    .style(
+                        Style::default()
+                            .bg(config.colors.warning.background)
+                            .fg(config.colors.warning.foreground),
+                    ),
                 Rect::new(0, data_frame_height, frame.size().width, 1),
             );
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -273,7 +273,7 @@ fn render_data(frame: &mut Frame, app: &App, config: &Config) {
         None => 0,
     };
 
-    if is_table(&value) {
+    if matches!(is_table(&value), crate::nu::value::Table::IsTable) {
         let (columns, shapes, cells) = match value {
             Value::List { vals, .. } => {
                 let recs = vals


### PR DESCRIPTION
this PR
- makes it that `nu::value::is_table` returns a `nu::value::Table` variant which hold more information about why the value is not a table
- adds a warning banner at the bottom to indicate the user why they are seeing a list of records
- adds a bunch of new tests for `is_table` for the new table variants
- make the colors of the warning banner configurable

> **Important**
> this will only work with #41, this can be achieved by running
> ```bash
> git merge bump-set_foreground
> ```
> on top of this commit