### PR TITLE
fix the rust toolchain version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.76"


### PR DESCRIPTION
this is to make sure the local version of Rust and the remote one in the CI are in sync and avoid CIs such as the one of https://github.com/amtoine/nu_plugin_explore/pull/30 to fail where the local one is working correctly.