### PR TITLE
update to latest nushell 0.90.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ name = "nu_plugin_explore"
 anyhow = "1.0.73"
 console = "0.15.7"
 crossterm = "0.27.0"
-nu-plugin = "0.89.0"
-nu-protocol = { version = "0.89.0", features = ["plugin"] }
+nu-plugin = { version = "0.90.2", path = "../nushell/crates/nu-plugin" }
+nu-protocol = { version = "0.90.2", path = "../nushell/crates/nu-protocol", features = ["plugin"] }
 ratatui = "0.22.0"
 url = "2.4.0"
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -37,7 +37,7 @@ impl Editor {
 
     pub(super) fn from_value(value: &Value) -> Self {
         Self {
-            buffer: value.into_string(" ", &nu_protocol::Config::default()),
+            buffer: value.to_abbreviated_string(&nu_protocol::Config::default()),
             cursor_position: (0, 0),
             width: 0,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ impl Plugin for Explore {
     fn run(
         &mut self,
         name: &str,
+        _config: &Option<Value>,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -19,7 +19,7 @@ pub enum Direction {
 /// return, you'd be able to scroll the list without seeing it as a whole... confusing, right?
 /// - cycle the list indices or the record column names => the index / column will wrap around
 ///
-/// > :bulb: **Note**  
+/// > :bulb: **Note**
 /// > this function will only modify the last element of the state's *cell path* either by
 /// > - not doing anything
 /// > - poping the last element to know where we are and then pushing back the new element
@@ -47,7 +47,8 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
             panic!(
                 "unexpected error when following {:?} in {}",
                 app.position.members,
-                app.value.into_string(" ", &nu_protocol::Config::default())
+                app.value
+                    .to_abbreviated_string(&nu_protocol::Config::default())
             )
         });
 
@@ -103,7 +104,7 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
 
 /// go one level deeper in the data
 ///
-/// > :bulb: **Note**  
+/// > :bulb: **Note**
 /// > this function will
 /// > - push a new *cell path* member to the state if there is more depth ahead
 /// > - mark the state as *at the bottom* if the value at the new depth is of a simple type
@@ -116,7 +117,8 @@ pub(super) fn go_deeper_in_data(app: &mut App) {
             panic!(
                 "unexpected error when following {:?} in {}",
                 app.position.members,
-                app.value.into_string(" ", &nu_protocol::Config::default())
+                app.value
+                    .to_abbreviated_string(&nu_protocol::Config::default())
             )
         });
 
@@ -137,7 +139,7 @@ pub(super) fn go_deeper_in_data(app: &mut App) {
 
 /// pop one level of depth from the data
 ///
-/// > :bulb: **Note**  
+/// > :bulb: **Note**
 /// > - the state is always marked as *not at the bottom*
 /// > - the state *cell path* can have it's last member popped if possible
 pub(super) fn go_back_in_data(app: &mut App) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -138,7 +138,7 @@ fn repr_simple_value(value: &Value) -> DataRowRepr {
         name: None,
         shape,
         // FIXME: use a real config
-        data: value.into_string(" ", &nu_protocol::Config::default()),
+        data: value.to_abbreviated_string(&nu_protocol::Config::default()),
     }
 }
 
@@ -252,7 +252,8 @@ fn render_data<B: Backend>(frame: &mut Frame<'_, B>, app: &App, config: &Config)
             panic!(
                 "unexpected error when following {:?} in {}",
                 app.position.members,
-                app.value.into_string(" ", &nu_protocol::Config::default())
+                app.value
+                    .to_abbreviated_string(&nu_protocol::Config::default())
             )
         });
 
@@ -469,7 +470,7 @@ fn render_data<B: Backend>(frame: &mut Frame<'_, B>, app: &App, config: &Config)
 /// this line can be removed through config, see [`crate::config::Config::show_cell_path`]
 ///
 /// # Examples
-/// > :bulb: **Note**  
+/// > :bulb: **Note**
 /// > the `...` are here to signify that the bar might be truncated and the `||` at the start and
 /// the end of the lines are just to represent the borders of the terminal but will not appear in
 /// the TUI.
@@ -513,7 +514,7 @@ fn render_cell_path<B: Backend>(frame: &mut Frame<'_, B>, app: &App) {
 /// the color depending of the mode is completely configurable!
 ///
 /// # Examples
-/// > :bulb: **Note**  
+/// > :bulb: **Note**
 /// > - the `...` are here to signify that the bar might be truncated and the `||` at the start and
 /// the end of the lines are just to represent the borders of the terminal but will not appear in
 /// the TUI.


### PR DESCRIPTION
Look closely at these string conversions. The nushell API for them changed pretty significantly. I was just trying to find something that works and the ones I chose may not be the right ones. I also don't really care for the use of `Record::from_raw_cols_vals` at all but I tried to make your existing code work by putting them in match statements.