### PR TITLE
use current Nushell executable in the build script

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -8,7 +8,7 @@ def main [package_file: path] {
     let name = open ($repo_root | path join "Cargo.toml") | get package.name
 
     cargo install --path $repo_root --root $install_root
-    nu --commands $"register ($install_root | path join "bin" $name)"
+    ^$nu.current-exe --commands $"register ($install_root | path join "bin" $name)"
 
     log info "do not forget to restart Nushell for the plugin to be fully available!"
 }


### PR DESCRIPTION
this is a minor fix in case there might be a `nu` binary in the `PATH` on top of the system `nu` one, with different versions.
this PR makes sure the one used inside the Nupm build script is the same as the currently running Nushell instance.