### PR TITLE
Fix panic on Mac from `crossterm::event::poll`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ nu-protocol = { version = "0.91.0", features = ["plugin"] }
 ratatui = "0.26.1"
 url = "2.4.0"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+crossterm = { version = "0.27.0", features = ["use-dev-tty"] }
+
 [lib]
 bench = false
 


### PR DESCRIPTION
Copied ver batim from sigoden/aichat#264.

### Background

- Identical bug: sigoden/aichat#257
- Request for docs: crossterm-rs/crossterm#849
- Similar bug: https://github.com/crossterm-rs/crossterm/issues/644#issuecomment-1073114710
- Source bug: crossterm-rs/crossterm#500
- Fix (enabled in this PR): crossterm-rs/crossterm#735

### Error

```
│hread '<unnamed>' panicked at src/event.rs:46:45:                                                             │
│o events available: Custom { kind: Other, error: "Failed to initialize input reader" }                        │
```

### Backtrace

In case of regression:

```diff
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│key                             bfield                                                                                                          shape           │
│version                          0.91.0                                                                                                         string          │
│branch                          c                                                                                                               string          │
│commit_hash                     d                                                                                                               string          │
│build_os                         macos-x86_64                                                                                                   string          │
│build_target                     x86_64-apple-darwin                                                                                            string          │
│rust_version                     rustc 1.76.0 (07dca489a 2024-02-04) (Homebrew)                                                                 string          │
│cargo_version                    cargo 1.76.0                                                                                                   string          │
│build_time                       2024-03-05 20:28:40 +00:00                                                                                     string          │
│build_rust_channel               release                                                                                                        string          │
│allocator                        mimalloc                                                                                                       string          │
│features                         dataframe, default, extra, sqlite, trash, which, zip                                                           string          │
│installed_plugins                nu_plugin_explore                                                                                              string          │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
│                                                                                                                                                                │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
cell path: $.version
 NORMAL                                                                                 i to INSERT | hjkl to move around | p to peek | t to transpose | q to quit   0:        0x101a6ab65 - std::backtrace_rs::backtrace::libunwind::trace::he87ba3c236c7ad5f
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1:        0x101a6ab65 - std::backtrace_rs::backtrace::trace_unsynchronized::h3ad5d899409e49ee
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x101a6ab65 - std::sys_common::backtrace::_print_fmt::hb1551f966d2dd86d
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:68:5
   3:        0x101a6ab65 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hbd71adb7a72f4105
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:44:22
   4:        0x101a8c993 - core::fmt::rt::Argument::fmt::h4224d647cce844bf
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/fmt/rt.rs:142:9
   5:        0x101a8c993 - core::fmt::write::h30346430340bc336
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/fmt/mod.rs:1120:17
   6:        0x101a67a8e - std::io::Write::write_fmt::heb3d6316c565d5b1
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/io/mod.rs:1810:15
   7:        0x101a6a939 - std::sys_common::backtrace::_print::hc99e5bf521524ac2
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:47:5
   8:        0x101a6a939 - std::sys_common::backtrace::print::h67e51ff2e3d5cfbd
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:34:9
   9:        0x101a6c575 - std::panicking::default_hook::{{closure}}::hc666c9a55318d1f1
  10:        0x101a6c2ee - std::panicking::default_hook::hf980b1da49948523
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:292:9
  11:        0x100e53d54 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h09d0f3f719801ec9
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2029:9
+ 12:        0x100e4c81d - nu_plugin_explore::tui::Tui<B>::init::{{closure}}::h92cf9edd04f48f7a
+                              at /Users/texas/Developer/git/nu_plugin_explore/src/tui.rs:45:13
  13:        0x101a6cb75 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h3a63db2ca77cedb5
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2029:9
  14:        0x101a6cb75 - std::panicking::rust_panic_with_hook::h683bce980186bbbe
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:783:13
  15:        0x101a6c904 - std::panicking::begin_panic_handler::{{closure}}::ha6dbd11ba0ec8af1
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:657:13
  16:        0x101a6b059 - std::sys_common::backtrace::__rust_end_short_backtrace::h889430bddc786c98
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:171:18
  17:        0x101a6c642 - rust_begin_unwind
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:645:5
  18:        0x101ab3f75 - core::panicking::panic_fmt::hff768cef35397791
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panicking.rs:72:14
  19:        0x101ab4535 - core::result::unwrap_failed::h951d84d71b0bada2
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/result.rs:1649:5
  20:        0x100e86f0f - core::result::Result<T,E>::expect::h46e49f62a7f5b691
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/result.rs:1030:23
+ 21:        0x100e39983 - nu_plugin_explore::event::EventHandler::new::{{closure}}::h6a786ba814d713f3
+                              at /Users/texas/Developer/git/nu_plugin_explore/src/event.rs:46:24
  22:        0x100e6d68d - std::sys_common::backtrace::__rust_begin_short_backtrace::h0d557fbf2c6545a9
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys_common/backtrace.rs:155:18
  23:        0x100e4f670 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::h49806568e55dc3ef
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/thread/mod.rs:529:17
  24:        0x100e39260 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::ha7914519392245f9
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panic/unwind_safe.rs:272:9
  25:        0x100e3dee0 - std::panicking::try::do_call::h77e6e80f923ba765
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:552:40
  26:        0x100e3df7d - ___rust_try
  27:        0x100e3de59 - std::panicking::try::hb72a1d854f6956b8
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:516:19
  28:        0x100e4f4ad - std::panic::catch_unwind::h35d42a1f268a9228
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panic.rs:142:14
  29:        0x100e4f4ad - std::thread::Builder::spawn_unchecked_::{{closure}}::hd42e13ba971d3218
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/thread/mod.rs:528:30
  30:        0x100e74451 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h6b49c774539034b2
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/ops/function.rs:250:5
  31:        0x101a712e9 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hef77fdfabbdc0490
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015:9
  32:        0x101a712e9 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hd4d34ecf6438f9ac
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015:9
  33:        0x101a712e9 - std::sys::unix::thread::Thread::new::thread_start::hcdd70219a480b010
                               at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys/unix/thread.rs:108:17
  34:     0x7ff81213918b - __pthread_start
```