### PR TITLE
check `Cargo.lock` in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - run: make check
 
       - name: Check Cargo.lock
-        run: if [[ -n $(git status --short Cargo.lock) ]]; then exit 1; fi
+        run: make lock
 
   tests:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ on:
 
 name: continuous-integration
 
-env:
-  CLIPPY_OPTIONS: "-D warnings"
-
 jobs:
   fmt-check-clippy:
     runs-on: ubuntu-20.04
@@ -21,17 +18,7 @@ jobs:
         with:
           rustflags: ""
 
-      - name: Format
-        run: cargo fmt --all -- --check
-
-      - name: Check the library
-        run: cargo check --workspace --lib
-
-      - name: Check the tests
-        run: cargo check --workspace --tests
-
-      - name: Clippy
-        run: cargo clippy --workspace -- $CLIPPY_OPTIONS
+      - run: make check
 
   tests:
     strategy:
@@ -49,5 +36,4 @@ jobs:
         with:
           rustflags: ""
 
-      - name: Tests
-        run: cargo test --workspace
+      - run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
 
       - run: make check
 
+      - name: Check Cargo.lock
+        run: if [[ -n $(git status --short Cargo.lock) ]]; then exit 1; fi
+
   tests:
     strategy:
       fail-fast: true

--- a/.github/workflows/scripts/check-cargo-lock.sh
+++ b/.github/workflows/scripts/check-cargo-lock.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[[ -n "$(git status --short Cargo.lock)" ]] && exit 1
+
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
+ "filedescriptor",
  "libc",
  "mio",
  "parking_lot",
@@ -456,6 +457,17 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,6 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
- "filedescriptor",
  "libc",
  "mio",
  "parking_lot",
@@ -457,17 +456,6 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "filedescriptor"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 CLIPPY_OPTIONS="-D warnings"
 
 .PHONY: all check test fmt doc build register install clean
-DEFAULT: check test
+DEFAULT: check lock test
 
 check:
 	cargo fmt --all --verbose -- --check --verbose
 	cargo check --workspace --lib --tests
 	cargo clippy --workspace -- "${CLIPPY_OPTIONS}"
+
+lock: check
+	./.github/workflows/scripts/check-cargo-lock.sh
 
 test: check
 	cargo test --workspace


### PR DESCRIPTION
## [changelog](https://github.com/amtoine/nu_plugin_explore/pull/43/commits)
- use the Makefile rules
- check the `Cargo.lock` file (see how the CI is failing because it's not up to date)
- update `Cargo.lock` (see how the CI becomes green again)