### PR TITLE
add support for motion repetition

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ pub enum Mode {
     /// the PEEKING mode lets the user *peek* data out of the application, to be reused later
     Peeking,
     Bottom,
+    Waiting(usize),
 }
 
 impl Default for Mode {
@@ -31,6 +32,7 @@ impl std::fmt::Display for Mode {
             Self::Insert => "INSERT",
             Self::Peeking => "PEEKING",
             Self::Bottom => "BOTTOM",
+            Self::Waiting(_) => "WAITING",
         };
         write!(f, "{}", repr)
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -56,36 +56,24 @@ pub fn handle_key_events(
             } else if key_event.modifiers == KeyModifiers::CONTROL
                 && key_event.code == KeyCode::Char('d')
             {
-                // TODO: don't go down when already at the bottom vertically
                 // FIXME: compute the real number of repetitions to go half a page down
                 // TODO: add a margin to the bottom
-                for _ in 0..10 {
-                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Down(10));
                 return Ok(TransitionResult::Continue);
             } else if key_event.modifiers == KeyModifiers::CONTROL
                 && key_event.code == KeyCode::Char('u')
             {
-                // TODO: don't go up when already at the top vertically
                 // FIXME: compute the real number of repetitions to go half a page up
                 // TODO: add a margin to the top
-                for _ in 0..10 {
-                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Up(10));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('G') {
-                // TODO: don't go down when already at the bottom vertically
                 // FIXME: compute the real number of repetitions to go to bottom
-                for _ in 0..1_000 {
-                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Down(1_000));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('g') {
-                // TODO: don't go up when already at the top vertically
                 // FIXME: compute the real number of repetitions to go to top
-                for _ in 0..1_000 {
-                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Up(1_000));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.quit {
                 return Ok(TransitionResult::Quit);
@@ -165,17 +153,11 @@ pub fn handle_key_events(
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.down {
                 app.mode = Mode::Normal;
-                // TODO: don't go down when already at the bottom vertically
-                for _ in 0..n {
-                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Down(n));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.up {
                 app.mode = Mode::Normal;
-                // TODO: don't go up when already at the top vertically
-                for _ in 0..n {
-                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
-                }
+                navigation::go_up_or_down_in_data(app, Direction::Up(n));
                 return Ok(TransitionResult::Continue);
             }
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -378,9 +378,6 @@ mod tests {
         assert_eq!(app.position.members, to_path_member_vec(&[PM::S("l")]));
 
         let transitions = vec![
-            (nav.up, vec![PM::S("i")], false),
-            (nav.up, vec![PM::S("s")], false),
-            (nav.up, vec![PM::S("r")], false),
             (nav.up, vec![PM::S("l")], false),
             (nav.down, vec![PM::S("r")], false),
             (nav.left, vec![PM::S("r")], false),
@@ -395,7 +392,7 @@ mod tests {
             (nav.down, vec![PM::S("r"), PM::S("b")], true),
             (nav.left, vec![PM::S("r"), PM::S("b")], false),
             (nav.up, vec![PM::S("r"), PM::S("a")], false),
-            (nav.up, vec![PM::S("r"), PM::S("b")], false),
+            (nav.up, vec![PM::S("r"), PM::S("a")], false),
             (nav.left, vec![PM::S("r")], false),
             (nav.down, vec![PM::S("s")], false),
             (nav.left, vec![PM::S("s")], false),
@@ -409,7 +406,9 @@ mod tests {
             (nav.up, vec![PM::S("i")], true),
             (nav.down, vec![PM::S("i")], true),
             (nav.left, vec![PM::S("i")], false),
-            (nav.down, vec![PM::S("l")], false),
+            (nav.up, vec![PM::S("s")], false),
+            (nav.up, vec![PM::S("r")], false),
+            (nav.up, vec![PM::S("l")], false),
             (nav.left, vec![PM::S("l")], false),
             (nav.right, vec![PM::S("l"), PM::I(0)], false),
             (nav.right, vec![PM::S("l"), PM::I(0)], true),
@@ -428,7 +427,7 @@ mod tests {
             (nav.left, vec![PM::S("l"), PM::I(2)], false),
             (nav.up, vec![PM::S("l"), PM::I(1)], false),
             (nav.up, vec![PM::S("l"), PM::I(0)], false),
-            (nav.up, vec![PM::S("l"), PM::I(2)], false),
+            (nav.up, vec![PM::S("l"), PM::I(0)], false),
             (nav.left, vec![PM::S("l")], false),
         ];
 
@@ -619,7 +618,7 @@ mod tests {
         let transitions = vec![
             (kmap.navigation.down, vec![PM::S("b")]),
             (kmap.transpose, vec![PM::I(0)]),
-            (kmap.navigation.up, vec![PM::I(2)]),
+            (kmap.navigation.down, vec![PM::I(1)]),
             (kmap.transpose, vec![PM::S("a")]),
         ];
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -110,7 +110,23 @@ pub fn handle_key_events(
             }
         }
         Mode::Waiting(n) => {
-            if key_event.code == KeyCode::Esc {
+            if key_event.code.ge(&KeyCode::Char('0')) && key_event.code.le(&KeyCode::Char('9')) {
+                let u = match key_event.code {
+                    KeyCode::Char('0') => 0,
+                    KeyCode::Char('1') => 1,
+                    KeyCode::Char('2') => 2,
+                    KeyCode::Char('3') => 3,
+                    KeyCode::Char('4') => 4,
+                    KeyCode::Char('5') => 5,
+                    KeyCode::Char('6') => 6,
+                    KeyCode::Char('7') => 7,
+                    KeyCode::Char('8') => 8,
+                    KeyCode::Char('9') => 9,
+                    _ => unreachable!(),
+                };
+                app.mode = Mode::Waiting(n * 10 + u);
+                return Ok(TransitionResult::Continue);
+            } else if key_event.code == KeyCode::Esc {
                 app.mode = Mode::Normal;
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.down {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -57,6 +57,8 @@ pub fn handle_key_events(
                 && key_event.code == KeyCode::Char('d')
             {
                 // TODO: don't go down when already at the bottom vertically
+                // FIXME: compute the real number of repetitions to go half a page down
+                // TODO: add a margin to the bottom
                 for _ in 0..10 {
                     navigation::go_up_or_down_in_data(app, Direction::Down);
                 }
@@ -65,18 +67,22 @@ pub fn handle_key_events(
                 && key_event.code == KeyCode::Char('u')
             {
                 // TODO: don't go up when already at the top vertically
+                // FIXME: compute the real number of repetitions to go half a page up
+                // TODO: add a margin to the top
                 for _ in 0..10 {
                     navigation::go_up_or_down_in_data(app, Direction::Up);
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('G') {
                 // TODO: don't go down when already at the bottom vertically
+                // FIXME: compute the real number of repetitions to go to bottom
                 for _ in 0..1_000 {
                     navigation::go_up_or_down_in_data(app, Direction::Down);
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('g') {
                 // TODO: don't go up when already at the top vertically
+                // FIXME: compute the real number of repetitions to go to top
                 for _ in 0..1_000 {
                     navigation::go_up_or_down_in_data(app, Direction::Up);
                 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -68,12 +68,10 @@ pub fn handle_key_events(
                 navigation::go_up_or_down_in_data(app, Direction::Up(10));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('G') {
-                // FIXME: compute the real number of repetitions to go to bottom
-                navigation::go_up_or_down_in_data(app, Direction::Down(1_000));
+                navigation::go_up_or_down_in_data(app, Direction::Bottom);
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('g') {
-                // FIXME: compute the real number of repetitions to go to top
-                navigation::go_up_or_down_in_data(app, Direction::Up(1_000));
+                navigation::go_up_or_down_in_data(app, Direction::Top);
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.quit {
                 return Ok(TransitionResult::Quit);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -115,12 +115,14 @@ pub fn handle_key_events(
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.down {
                 app.mode = Mode::Normal;
+                // TODO: don't go down when already at the bottom vertically
                 for _ in 0..n {
                     navigation::go_up_or_down_in_data(app, Direction::Down);
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.up {
                 app.mode = Mode::Normal;
+                // TODO: don't go up when already at the top vertically
                 for _ in 0..n {
                     navigation::go_up_or_down_in_data(app, Direction::Up);
                 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -60,7 +60,7 @@ pub fn handle_key_events(
                 // FIXME: compute the real number of repetitions to go half a page down
                 // TODO: add a margin to the bottom
                 for _ in 0..10 {
-                    navigation::go_up_or_down_in_data(app, Direction::Down);
+                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.modifiers == KeyModifiers::CONTROL
@@ -70,21 +70,21 @@ pub fn handle_key_events(
                 // FIXME: compute the real number of repetitions to go half a page up
                 // TODO: add a margin to the top
                 for _ in 0..10 {
-                    navigation::go_up_or_down_in_data(app, Direction::Up);
+                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('G') {
                 // TODO: don't go down when already at the bottom vertically
                 // FIXME: compute the real number of repetitions to go to bottom
                 for _ in 0..1_000 {
-                    navigation::go_up_or_down_in_data(app, Direction::Down);
+                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == KeyCode::Char('g') {
                 // TODO: don't go up when already at the top vertically
                 // FIXME: compute the real number of repetitions to go to top
                 for _ in 0..1_000 {
-                    navigation::go_up_or_down_in_data(app, Direction::Up);
+                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.quit {
@@ -98,10 +98,10 @@ pub fn handle_key_events(
                 app.mode = Mode::Peeking;
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.down {
-                navigation::go_up_or_down_in_data(app, Direction::Down);
+                navigation::go_up_or_down_in_data(app, Direction::Down(1));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.up {
-                navigation::go_up_or_down_in_data(app, Direction::Up);
+                navigation::go_up_or_down_in_data(app, Direction::Up(1));
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.right {
                 navigation::go_deeper_in_data(app);
@@ -167,14 +167,14 @@ pub fn handle_key_events(
                 app.mode = Mode::Normal;
                 // TODO: don't go down when already at the bottom vertically
                 for _ in 0..n {
-                    navigation::go_up_or_down_in_data(app, Direction::Down);
+                    navigation::go_up_or_down_in_data(app, Direction::Down(1));
                 }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.navigation.up {
                 app.mode = Mode::Normal;
                 // TODO: don't go up when already at the top vertically
                 for _ in 0..n {
-                    navigation::go_up_or_down_in_data(app, Direction::Up);
+                    navigation::go_up_or_down_in_data(app, Direction::Up(1));
                 }
                 return Ok(TransitionResult::Continue);
             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use nu_protocol::{
     ast::{CellPath, PathMember},
@@ -52,6 +52,34 @@ pub fn handle_key_events(
                     KeyCode::Char('9') => 9,
                     _ => unreachable!(),
                 });
+                return Ok(TransitionResult::Continue);
+            } else if key_event.modifiers == KeyModifiers::CONTROL
+                && key_event.code == KeyCode::Char('d')
+            {
+                // TODO: don't go down when already at the bottom vertically
+                for _ in 0..10 {
+                    navigation::go_up_or_down_in_data(app, Direction::Down);
+                }
+                return Ok(TransitionResult::Continue);
+            } else if key_event.modifiers == KeyModifiers::CONTROL
+                && key_event.code == KeyCode::Char('u')
+            {
+                // TODO: don't go up when already at the top vertically
+                for _ in 0..10 {
+                    navigation::go_up_or_down_in_data(app, Direction::Up);
+                }
+                return Ok(TransitionResult::Continue);
+            } else if key_event.code == KeyCode::Char('G') {
+                // TODO: don't go down when already at the bottom vertically
+                for _ in 0..1_000 {
+                    navigation::go_up_or_down_in_data(app, Direction::Down);
+                }
+                return Ok(TransitionResult::Continue);
+            } else if key_event.code == KeyCode::Char('g') {
+                // TODO: don't go up when already at the top vertically
+                for _ in 0..1_000 {
+                    navigation::go_up_or_down_in_data(app, Direction::Up);
+                }
                 return Ok(TransitionResult::Continue);
             } else if key_event.code == config.keybindings.quit {
                 return Ok(TransitionResult::Quit);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -157,6 +157,10 @@ pub fn handle_key_events(
                 app.mode = Mode::Normal;
                 navigation::go_up_or_down_in_data(app, Direction::Up(n));
                 return Ok(TransitionResult::Continue);
+            } else if key_event.code == KeyCode::Char('g') {
+                app.mode = Mode::Normal;
+                navigation::go_up_or_down_in_data(app, Direction::At(n));
+                return Ok(TransitionResult::Continue);
             }
         }
         Mode::Insert => {

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -59,8 +59,8 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                         val
                     } else {
                         match direction {
-                            Direction::Up(step) => (val - step).max(0),
-                            Direction::Down(step) => (val + step).min(vals.len() - 1),
+                            Direction::Up(step) => val.saturating_sub(step).max(0),
+                            Direction::Down(step) => val.saturating_add(step).min(vals.len() - 1),
                         }
                     },
                     span,
@@ -85,8 +85,10 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                         } else {
                             let index = rec.columns().position(|x| x == &val).unwrap();
                             let new_index = match direction {
-                                Direction::Up(step) => (index - step).max(0),
-                                Direction::Down(step) => (index + step).min(cols.len() - 1),
+                                Direction::Up(step) => index.saturating_sub(step).max(0),
+                                Direction::Down(step) => {
+                                    index.saturating_add(step).min(cols.len() - 1)
+                                }
                             };
 
                             cols[new_index].clone()

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -191,9 +191,9 @@ mod tests {
         let sequence = vec![
             (Direction::Down(1), 1),
             (Direction::Down(1), 2),
-            (Direction::Down(1), 0),
-            (Direction::Up(1), 2),
+            (Direction::Down(1), 2),
             (Direction::Up(1), 1),
+            (Direction::Up(1), 0),
             (Direction::Up(1), 0),
         ];
         for (direction, id) in sequence {
@@ -215,9 +215,9 @@ mod tests {
         let sequence = vec![
             (Direction::Down(1), "b"),
             (Direction::Down(1), "c"),
-            (Direction::Down(1), "a"),
-            (Direction::Up(1), "c"),
+            (Direction::Down(1), "c"),
             (Direction::Up(1), "b"),
+            (Direction::Up(1), "a"),
             (Direction::Up(1), "a"),
         ];
         for (direction, id) in sequence {

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -9,6 +9,10 @@ pub enum Direction {
     Down(usize),
     /// go up in the data
     Up(usize),
+    /// go to the top of the data, i.e. the first element or the first key
+    Top,
+    /// go to the bottom of the data, i.e. the last element or the last key
+    Bottom,
 }
 
 /// go up or down in the data
@@ -61,6 +65,8 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                         match direction {
                             Direction::Up(step) => val.saturating_sub(step).max(0),
                             Direction::Down(step) => val.saturating_add(step).min(vals.len() - 1),
+                            Direction::Top => 0,
+                            Direction::Bottom => vals.len() - 1,
                         }
                     },
                     span,
@@ -89,6 +95,8 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                                 Direction::Down(step) => {
                                     index.saturating_add(step).min(cols.len() - 1)
                                 }
+                                Direction::Top => 0,
+                                Direction::Bottom => cols.len() - 1,
                             };
 
                             cols[new_index].clone()
@@ -195,6 +203,10 @@ mod tests {
             (Direction::Up(1), 1),
             (Direction::Up(1), 0),
             (Direction::Up(1), 0),
+            (Direction::Top, 0),
+            (Direction::Bottom, 2),
+            (Direction::Bottom, 2),
+            (Direction::Top, 0),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);
@@ -219,6 +231,10 @@ mod tests {
             (Direction::Up(1), "b"),
             (Direction::Up(1), "a"),
             (Direction::Up(1), "a"),
+            (Direction::Top, "a"),
+            (Direction::Bottom, "c"),
+            (Direction::Bottom, "c"),
+            (Direction::Top, "a"),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -5,10 +5,10 @@ use crate::app::{App, Mode};
 
 /// specify a vertical direction in which to go in the data
 pub enum Direction {
-    /// go one row down in the data
-    Down,
-    /// go one row up in the data
-    Up,
+    /// go down in the data
+    Down(usize),
+    /// go up in the data
+    Up(usize),
 }
 
 /// go up or down in the data
@@ -59,8 +59,8 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                         val
                     } else {
                         match direction {
-                            Direction::Up => (val - 1).max(0),
-                            Direction::Down => (val + 1).min(vals.len() - 1),
+                            Direction::Up(step) => (val - step).max(0),
+                            Direction::Down(step) => (val + step).min(vals.len() - 1),
                         }
                     },
                     span,
@@ -83,13 +83,13 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                         val: if cols.is_empty() {
                             "".into()
                         } else {
-                            let index = rec.columns().position(|x| x == &val).unwrap() as i32;
+                            let index = rec.columns().position(|x| x == &val).unwrap();
                             let new_index = match direction {
-                                Direction::Up => (index - 1).max(0),
-                                Direction::Down => (index + 1).min((cols.len() - 1) as i32),
+                                Direction::Up(step) => (index - step).max(0),
+                                Direction::Down(step) => (index + step).min(cols.len() - 1),
                             };
 
-                            cols[new_index as usize].clone()
+                            cols[new_index].clone()
                         },
                         span,
                         optional,
@@ -187,12 +187,12 @@ mod tests {
         let mut app = App::from_value(value);
 
         let sequence = vec![
-            (Direction::Down, 1),
-            (Direction::Down, 2),
-            (Direction::Down, 0),
-            (Direction::Up, 2),
-            (Direction::Up, 1),
-            (Direction::Up, 0),
+            (Direction::Down(1), 1),
+            (Direction::Down(1), 2),
+            (Direction::Down(1), 0),
+            (Direction::Up(1), 2),
+            (Direction::Up(1), 1),
+            (Direction::Up(1), 0),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);
@@ -211,12 +211,12 @@ mod tests {
         let mut app = App::from_value(value);
 
         let sequence = vec![
-            (Direction::Down, "b"),
-            (Direction::Down, "c"),
-            (Direction::Down, "a"),
-            (Direction::Up, "c"),
-            (Direction::Up, "b"),
-            (Direction::Up, "a"),
+            (Direction::Down(1), "b"),
+            (Direction::Down(1), "c"),
+            (Direction::Down(1), "a"),
+            (Direction::Up(1), "c"),
+            (Direction::Up(1), "b"),
+            (Direction::Up(1), "a"),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -13,6 +13,8 @@ pub enum Direction {
     Top,
     /// go to the bottom of the data, i.e. the last element or the last key
     Bottom,
+    /// go at a particular line in the data
+    At(usize),
 }
 
 /// go up or down in the data
@@ -67,6 +69,7 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                             Direction::Down(step) => val.saturating_add(step).min(vals.len() - 1),
                             Direction::Top => 0,
                             Direction::Bottom => vals.len() - 1,
+                            Direction::At(id) => id.min(vals.len() - 1),
                         }
                     },
                     span,
@@ -97,6 +100,7 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                                 }
                                 Direction::Top => 0,
                                 Direction::Bottom => cols.len() - 1,
+                                Direction::At(id) => id.min(cols.len() - 1),
                             };
 
                             cols[new_index].clone()
@@ -207,6 +211,9 @@ mod tests {
             (Direction::Bottom, 2),
             (Direction::Bottom, 2),
             (Direction::Top, 0),
+            (Direction::At(0), 0),
+            (Direction::At(1), 1),
+            (Direction::At(2), 2),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);
@@ -235,6 +242,9 @@ mod tests {
             (Direction::Bottom, "c"),
             (Direction::Bottom, "c"),
             (Direction::Top, "a"),
+            (Direction::At(0), "a"),
+            (Direction::At(1), "b"),
+            (Direction::At(2), "c"),
         ];
         for (direction, id) in sequence {
             go_up_or_down_in_data(&mut app, direction);

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -28,11 +28,6 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
         return;
     }
 
-    let direction = match direction {
-        Direction::Up => -1,
-        Direction::Down => 1,
-    };
-
     let current = app
         .position
         .members
@@ -63,10 +58,10 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                     val: if vals.is_empty() {
                         val
                     } else {
-                        let len = vals.len() as i32;
-                        let new_index = (val as i32 + direction + len) % len;
-
-                        new_index as usize
+                        match direction {
+                            Direction::Up => (val - 1).max(0),
+                            Direction::Down => (val + 1).min(vals.len() - 1),
+                        }
                     },
                     span,
                     optional,
@@ -89,8 +84,10 @@ pub(super) fn go_up_or_down_in_data(app: &mut App, direction: Direction) {
                             "".into()
                         } else {
                             let index = rec.columns().position(|x| x == &val).unwrap() as i32;
-                            let len = cols.len() as i32;
-                            let new_index = (index + direction + len) % len;
+                            let new_index = match direction {
+                                Direction::Up => (index - 1).max(0),
+                                Direction::Down => (index + 1).min((cols.len() - 1) as i32),
+                            };
 
                             cols[new_index as usize].clone()
                         },

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -564,14 +564,16 @@ fn render_status_bar(frame: &mut Frame, app: &App, config: &Config) {
     let bottom_bar_rect = Rect::new(0, frame.size().height - 1, frame.size().width, 1);
 
     let bg_style = match app.mode {
-        Mode::Normal => Style::default().bg(config.colors.status_bar.normal.background),
+        Mode::Normal | Mode::Waiting(_) => {
+            Style::default().bg(config.colors.status_bar.normal.background)
+        }
         Mode::Insert => Style::default().bg(config.colors.status_bar.insert.background),
         Mode::Peeking => Style::default().bg(config.colors.status_bar.peek.background),
         Mode::Bottom => Style::default().bg(config.colors.status_bar.bottom.background),
     };
 
     let style = match app.mode {
-        Mode::Normal => bg_style.fg(config.colors.status_bar.normal.foreground),
+        Mode::Normal | Mode::Waiting(_) => bg_style.fg(config.colors.status_bar.normal.foreground),
         Mode::Insert => bg_style.fg(config.colors.status_bar.insert.foreground),
         Mode::Peeking => bg_style.fg(config.colors.status_bar.peek.foreground),
         Mode::Bottom => bg_style.fg(config.colors.status_bar.bottom.foreground),
@@ -589,6 +591,11 @@ fn render_status_bar(frame: &mut Frame, app: &App, config: &Config) {
             repr_keycode(&config.keybindings.peek),
             repr_keycode(&config.keybindings.transpose),
             repr_keycode(&config.keybindings.quit),
+        ),
+        Mode::Waiting(n) => format!(
+            "{} to quit | will run next motion {} times",
+            repr_keycode(&KeyCode::Esc),
+            n
         ),
         Mode::Insert => format!(
             "{} to quit | {}{}{}{} to move the cursor | {}{} to delete characters | {} to confirm",


### PR DESCRIPTION
this PR adds the following support
- in NORMAL mode, enter a number _n_ and then press `config.keybindings.navigation.down` to go down _n_ rows
- in NORMAL mode, enter a number _n_ and then press `config.keybindings.navigation.up` to go up _n_ rows
- in NORMAL mode, enter a number _n_ and then press _g_ to jump to line number _n_
- in NORMAL mode, press _control + d_ to jump half a page down (half page size is hardcoded for now)
- in NORMAL mode, press _control + u_ to jump half a page up (half page size is hardcoded for now)
- in NORMAL mode, press _g_ to jump to the top
- in NORMAL mode, press _G_ to jump to the bottom