### PR TITLE
make sure the bottom of the data stays at the bottom

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -335,13 +335,13 @@ fn render_data(frame: &mut Frame, app: &mut App, config: &Config) {
         app.rendering_tops.pop();
         app.rendering_tops.push(
             (cursor - height + margin + 1)
-                .max(0)
-                .min(nb_lines as i32 - height),
+                .min(nb_lines as i32 - height)
+                .max(0),
         );
     } else if cursor <= top + margin {
         app.rendering_tops.pop();
         app.rendering_tops
-            .push((cursor - margin).max(0).min(nb_lines as i32 - height));
+            .push((cursor - margin).min(nb_lines as i32 - height).max(0));
     }
 
     let margin_offset = *app.rendering_tops.last().unwrap_or(&0) as usize;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -333,11 +333,15 @@ fn render_data(frame: &mut Frame, app: &mut App, config: &Config) {
 
     if cursor >= top + height - margin {
         app.rendering_tops.pop();
-        app.rendering_tops
-            .push((cursor - height + margin + 1).max(0));
+        app.rendering_tops.push(
+            (cursor - height + margin + 1)
+                .max(0)
+                .min(nb_lines as i32 - height),
+        );
     } else if cursor <= top + margin {
         app.rendering_tops.pop();
-        app.rendering_tops.push((cursor - margin).max(0));
+        app.rendering_tops
+            .push((cursor - margin).max(0).min(nb_lines as i32 - height));
     }
 
     let margin_offset = *app.rendering_tops.last().unwrap_or(&0) as usize;


### PR DESCRIPTION
in large data, getting close to the bottom would make the last element "lift off" the bottom of the frame, leaving empty lines below it even though there is enough lines to fill the entire frame...

this PR constrains the "tops" to be less than `nb_lines - height`, forcing the last element of the data to always be at the bottom if there are enough lines to fill the frame.