### PR TITLE
bump to `0.92.3-c06ef201b72b3cbe901820417106b7d65c6f01e1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "nu-engine"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1005,12 +1005,12 @@ dependencies = [
 [[package]]
 name = "nu-glob"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 
 [[package]]
 name = "nu-parser"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "nu-path"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "nu-plugin"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "bincode",
  "interprocess",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "nu-protocol"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "nu-system"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "chrono",
  "libc",
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "nu-utils"
 version = "0.92.3"
-source = "git+https://github.com/devyn/nushell?branch=plugin-local-socket#bfe2092b3da71b34a57ef48926a146f658e53fdb"
+source = "git+https://github.com/nushell/nushell?rev=c06ef201b72b3cbe901820417106b7d65c6f01e1#c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_explore"
-version = "0.92.3"
+version = "0.92.3-c06ef201b72b3cbe901820417106b7d65c6f01e1"
 dependencies = [
  "anyhow",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ name = "nu_plugin_explore"
 anyhow = "1.0.73"
 console = "0.15.7"
 crossterm = "0.27.0"
-nu-plugin = { git = "https://github.com/devyn/nushell", branch = "plugin-local-socket", package = "nu-plugin" }
-nu-protocol = { git = "https://github.com/devyn/nushell", branch = "plugin-local-socket", package = "nu-protocol", features = ["plugin"] }
-nu-parser = { git = "https://github.com/devyn/nushell", branch = "plugin-local-socket", package = "nu-parser" }
+nu-plugin = { git = "https://github.com/nushell/nushell", rev = "c06ef201b72b3cbe901820417106b7d65c6f01e1", package = "nu-plugin" }
+nu-protocol = { git = "https://github.com/nushell/nushell", rev = "c06ef201b72b3cbe901820417106b7d65c6f01e1", package = "nu-protocol", features = ["plugin"] }
+nu-parser = { git = "https://github.com/nushell/nushell", rev = "c06ef201b72b3cbe901820417106b7d65c6f01e1", package = "nu-parser" }
 ratatui = "0.26.1"
 url = "2.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ bench = false
 [package]
 edition = "2021"
 name = "nu_plugin_explore"
-version = "0.92.3"
+version = "0.92.3-c06ef201b72b3cbe901820417106b7d65c6f01e1"

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,6 +1,6 @@
 {
     name: nu_plugin_explore,
-    version: "0.1.2",
+    version: "0.92.3-c06ef201b72b3cbe901820417106b7d65c6f01e1",
     description: "A fast structured data explorer for Nushell.",
     license: LICENSE,
     type: custom


### PR DESCRIPTION
related to
- nushell/nushell#12448

this PR on the Nushell side just landed, it's time to bump `nu_plugin_explore`

## changelog
- point to nushell/nushell@c06ef201b72b3cbe901820417106b7d65c6f01e1
- bump the plugin to version `0.92.3-c06ef201b72b3cbe901820417106b7d65c6f01e1`