### PR TITLE
bump to `0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +236,27 @@ dependencies = [
  "quote",
  "syn 2.0.59",
  "syn_derive",
+]
+
+[[package]]
+name = "brotli"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -994,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "nu-engine"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1005,12 +1041,12 @@ dependencies = [
 [[package]]
 name = "nu-glob"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 
 [[package]]
 name = "nu-parser"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1025,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "nu-path"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -1035,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "nu-plugin"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "bincode",
  "interprocess",
@@ -1058,8 +1094,9 @@ dependencies = [
 [[package]]
 name = "nu-protocol"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
+ "brotli",
  "byte-unit",
  "chrono",
  "chrono-humanize",
@@ -1071,6 +1108,7 @@ dependencies = [
  "nu-system",
  "nu-utils",
  "num-format",
+ "rmp-serde",
  "serde",
  "serde_json",
  "thiserror",
@@ -1080,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "nu-system"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "chrono",
  "libc",
@@ -1098,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "nu-utils"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1113,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_explore"
-version = "0.92.3-be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+version = "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "anyhow",
  "console",
@@ -1147,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "nuon"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=be5ed3290cb116cbe9f3038f7a2d46aaac85a25c#be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
 dependencies = [
  "fancy-regex",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ bench = false
 [package]
 edition = "2021"
 name = "nu_plugin_explore"
-version = "0.92.3-be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+version = "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ name = "nu_plugin_explore"
 anyhow = "1.0.73"
 console = "0.15.7"
 crossterm = "0.27.0"
-nuon = { git = "https://github.com/nushell/nushell", rev = "be5ed3290cb116cbe9f3038f7a2d46aaac85a25c", package = "nuon" }
-nu-plugin = { git = "https://github.com/nushell/nushell", rev = "be5ed3290cb116cbe9f3038f7a2d46aaac85a25c", package = "nu-plugin" }
-nu-protocol = { git = "https://github.com/nushell/nushell", rev = "be5ed3290cb116cbe9f3038f7a2d46aaac85a25c", package = "nu-protocol", features = ["plugin"] }
+nuon = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nuon" }
+nu-plugin = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-plugin" }
+nu-protocol = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-protocol", features = ["plugin"] }
 ratatui = "0.26.1"
 url = "2.4.0"
 

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,6 +1,6 @@
 {
     name: nu_plugin_explore,
-    version: "0.92.3-be5ed3290cb116cbe9f3038f7a2d46aaac85a25c"
+    version: "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"
     description: "A fast structured data explorer for Nushell.",
     license: LICENSE,
     type: custom


### PR DESCRIPTION
makes `nu_plugin_explore` on par with nushell/nushell@2595f31541554c6d8602ebebc9dffbc4dd29dd89