### PR TITLE
Don't merge it....try to update nushell on latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "nu-engine"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1041,12 +1041,12 @@ dependencies = [
 [[package]]
 name = "nu-glob"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 
 [[package]]
 name = "nu-parser"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "nu-path"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -1071,30 +1071,49 @@ dependencies = [
 [[package]]
 name = "nu-plugin"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
- "bincode",
- "interprocess",
  "log",
- "miette",
  "nix",
  "nu-engine",
+ "nu-plugin-core",
+ "nu-plugin-protocol",
  "nu-protocol",
- "nu-system",
- "nu-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "nu-plugin-core"
+version = "0.92.3"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
+dependencies = [
+ "interprocess",
+ "log",
+ "nu-plugin-protocol",
+ "nu-protocol",
  "rmp-serde",
- "semver",
  "serde",
  "serde_json",
- "thiserror",
- "typetag",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "nu-plugin-protocol"
+version = "0.92.3"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
+dependencies = [
+ "bincode",
+ "nu-protocol",
+ "nu-utils",
+ "semver",
+ "serde",
+ "typetag",
 ]
 
 [[package]]
 name = "nu-protocol"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -1118,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "nu-system"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "chrono",
  "libc",
@@ -1136,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "nu-utils"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1185,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "nuon"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=59ee96c70d2aa2d1d24d364eebe9c711700e3155#59ee96c70d2aa2d1d24d364eebe9c711700e3155"
 dependencies = [
  "fancy-regex",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ name = "nu_plugin_explore"
 anyhow = "1.0.73"
 console = "0.15.7"
 crossterm = "0.27.0"
-nuon = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nuon" }
-nu-plugin = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-plugin" }
-nu-protocol = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-protocol", features = ["plugin"] }
+nuon = { git = "https://github.com/nushell/nushell", rev = "59ee96c70d2aa2d1d24d364eebe9c711700e3155", package = "nuon" }
+nu-plugin = { git = "https://github.com/nushell/nushell", rev = "59ee96c70d2aa2d1d24d364eebe9c711700e3155", package = "nu-plugin" }
+nu-protocol = { git = "https://github.com/nushell/nushell", rev = "59ee96c70d2aa2d1d24d364eebe9c711700e3155", package = "nu-protocol", features = ["plugin"] }
 ratatui = "0.26.1"
 url = "2.4.0"
 

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -136,9 +136,12 @@ pub(crate) fn is_table(value: &Value) -> Table {
             let mut rows = Vec::new();
             for (i, val) in vals.iter().enumerate() {
                 match val.get_type() {
-                    Type::Record(fields) => {
-                        rows.push(fields.into_iter().collect::<HashMap<String, Type>>())
-                    }
+                    Type::Record(fields) => rows.push(
+                        fields
+                            .into_iter()
+                            .cloned()
+                            .collect::<HashMap<String, Type>>(),
+                    ),
                     t => return Table::RowNotARecord(i, t),
                 };
             }


### PR DESCRIPTION
An error happened when trying to update dependencies to latest main:
```
❯ open Cargo.toml | nu_plugin_explore
Error:   × Can't start nu_plugin_explore
   ╭─[entry #8:1:19]
 1 │ open Cargo.toml | nu_plugin_explore
   ·                   ────────┬────────
   ·                           ╰── must run in a terminal
   ╰────
  help: ensure that you are running in a terminal, and that the plugin is not communicating over stdio

```