### PR TITLE
Fix TUI channel panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "nu-engine"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1022,12 +1022,12 @@ dependencies = [
 [[package]]
 name = "nu-glob"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 
 [[package]]
 name = "nu-parser"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "nu-path"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -1052,30 +1052,49 @@ dependencies = [
 [[package]]
 name = "nu-plugin"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
- "bincode",
- "interprocess",
  "log",
- "miette",
  "nix",
  "nu-engine",
+ "nu-plugin-core",
+ "nu-plugin-protocol",
  "nu-protocol",
- "nu-system",
- "nu-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "nu-plugin-core"
+version = "0.92.3"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+dependencies = [
+ "interprocess",
+ "log",
+ "nu-plugin-protocol",
+ "nu-protocol",
  "rmp-serde",
- "semver",
  "serde",
  "serde_json",
- "thiserror",
- "typetag",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "nu-plugin-protocol"
+version = "0.92.3"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+dependencies = [
+ "bincode",
+ "nu-protocol",
+ "nu-utils",
+ "semver",
+ "serde",
+ "typetag",
 ]
 
 [[package]]
 name = "nu-protocol"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -1099,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "nu-system"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "chrono",
  "libc",
@@ -1117,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "nu-utils"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1132,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_explore"
-version = "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+version = "0.92.3-37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -1165,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "nuon"
 version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=2595f31541554c6d8602ebebc9dffbc4dd29dd89#2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
 dependencies = [
  "fancy-regex",
  "nu-engine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,8 +1010,8 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -1021,13 +1021,13 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 
 [[package]]
 name = "nu-parser"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1041,8 +1041,8 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -1051,8 +1051,8 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "log",
  "nix",
@@ -1065,8 +1065,8 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "interprocess",
  "log",
@@ -1080,8 +1080,8 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "bincode",
  "nu-protocol",
@@ -1093,8 +1093,8 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -1117,8 +1117,8 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "chrono",
  "libc",
@@ -1135,8 +1135,8 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_explore"
-version = "0.92.3-37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -1183,8 +1183,8 @@ dependencies = [
 
 [[package]]
 name = "nuon"
-version = "0.92.3"
-source = "git+https://github.com/nushell/nushell?rev=37123950043c1fe5e60174ed32d72e03fc3d7c66#37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"
+source = "git+https://github.com/nushell/nushell?tag=0.93.0#3b220e07e3e3652bc722d4bc8370f2413df69473"
 dependencies = [
  "fancy-regex",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ name = "nu_plugin_explore"
 [dependencies]
 anyhow = "1.0.73"
 crossterm = "0.27.0"
-nuon = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nuon" }
-nu-plugin = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-plugin" }
-nu-protocol = { git = "https://github.com/nushell/nushell", rev = "2595f31541554c6d8602ebebc9dffbc4dd29dd89", package = "nu-protocol", features = ["plugin"] }
+nuon = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nuon" }
+nu-plugin = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nu-plugin" }
+nu-protocol = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nu-protocol", features = ["plugin"] }
 ratatui = "0.26.1"
 url = "2.4.0"
 
@@ -20,4 +20,4 @@ bench = false
 [package]
 edition = "2021"
 name = "nu_plugin_explore"
-version = "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+version = "0.92.3-37123950043c1fe5e60174ed32d72e03fc3d7c66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ name = "nu_plugin_explore"
 [dependencies]
 anyhow = "1.0.73"
 crossterm = "0.27.0"
-nuon = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nuon" }
-nu-plugin = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nu-plugin" }
-nu-protocol = { git = "https://github.com/nushell/nushell", rev = "37123950043c1fe5e60174ed32d72e03fc3d7c66", package = "nu-protocol", features = ["plugin"] }
+nuon = { git = "https://github.com/nushell/nushell", tag = "0.93.0", package = "nuon" }
+nu-plugin = { git = "https://github.com/nushell/nushell", tag = "0.93.0", package = "nu-plugin" }
+nu-protocol = { git = "https://github.com/nushell/nushell", tag = "0.93.0", package = "nu-protocol", features = ["plugin"] }
 ratatui = "0.26.1"
 url = "2.4.0"
 
@@ -20,4 +20,4 @@ bench = false
 [package]
 edition = "2021"
 name = "nu_plugin_explore"
-version = "0.92.3-37123950043c1fe5e60174ed32d72e03fc3d7c66"
+version = "0.93.0"

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,6 +1,6 @@
 {
     name: nu_plugin_explore,
-    version: "0.92.3-2595f31541554c6d8602ebebc9dffbc4dd29dd89"
+    version: "0.93.0",
     description: "A fast structured data explorer for Nushell.",
     license: LICENSE,
     type: custom

--- a/src/nu/value.rs
+++ b/src/nu/value.rs
@@ -136,9 +136,11 @@ pub(crate) fn is_table(value: &Value) -> Table {
             let mut rows = Vec::new();
             for (i, val) in vals.iter().enumerate() {
                 match val.get_type() {
-                    Type::Record(fields) => {
-                        rows.push(fields.into_iter().collect::<HashMap<String, Type>>())
-                    }
+                    Type::Record(fields) => rows.push(
+                        Vec::from(fields)
+                            .into_iter()
+                            .collect::<HashMap<String, Type>>(),
+                    ),
                     t => return Table::RowNotARecord(i, t),
                 };
             }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -44,17 +44,21 @@ impl EventHandler {
                         .unwrap_or(tick_rate);
 
                     if event::poll(timeout).expect("no events available") {
-                        match event::read().expect("unable to read event") {
+                        let result = match event::read().expect("unable to read event") {
                             CrosstermEvent::Key(e) => sender.send(Event::Key(e)),
                             CrosstermEvent::Mouse(e) => sender.send(Event::Mouse(e)),
                             CrosstermEvent::Resize(w, h) => sender.send(Event::Resize(w, h)),
                             _ => Ok(()),
+                        };
+                        if result.is_err() {
+                            break;
                         }
-                        .expect("failed to send terminal event")
                     }
 
                     if last_tick.elapsed() >= tick_rate {
-                        sender.send(Event::Tick).expect("failed to send tick event");
+                        if sender.send(Event::Tick).is_err() {
+                            break;
+                        }
                         last_tick = Instant::now();
                     }
                 }


### PR DESCRIPTION
Fix panics when sending to the TUI channel.

Because failing to send just means the other end hung up, we don't really need to do anything special. It's totally expected that the other side will hang up eventually. It's best for us to just break out of the loop.

This also updates nushell to a revision I have right now that fixes local socket, but this should probably be changed on release.
