### PR TITLE
improve long data performance

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -299,7 +299,10 @@ fn render_data(frame: &mut Frame, app: &mut App) {
     let rect_without_bottom_bar =
         Rect::new(line_numbers_width, 0, frame.size().width, data_frame_height);
 
-    let height = data_frame_height as i32 - 3; // 3: border x 2 + header
+    let height = match config.layout {
+        Layout::Compact => data_frame_height as i32,
+        Layout::Table => data_frame_height as i32 - 3, // 3: border x 2 + header
+    };
     let cursor = selected as i32;
     let top = *app.rendering_tops.last().unwrap_or(&0);
     let margin = config.margin as i32;


### PR DESCRIPTION
cc/ @kubouch

in this PR, the rendering of data with rows will only compute the rendered strings for the rows in the frame.

from what i've seen, it looks like it allows to run `nu_plugin_explore` on data longer by around an order of magnitude :thinking: 

- before this PR
  - `seq 1 100_000 | nu_plugin_explore` is already pretty slow (slower than with `seq 1 1_000_000` below)
  - `seq 1 1_000_000 | nu_plugin_explore` is absolutely unusable
- with this PR
  - `seq 1 100_000 | nu_plugin_explore` is very responsive
  - `seq 1 1_000_000 | nu_plugin_explore` starts to feel a bit slow

## bonus
this PR also fixes the height of the frame in the _compact_ layout, making it consistent with the _table_ layout and the rendering style of true tables.